### PR TITLE
feat: Sort library by last read

### DIFF
--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -74,13 +74,15 @@ enum MangaSort {
   alphabetical,
   dateAdded,
   unread,
-  lastUpdated;
+  lastUpdated,
+  lastRead;
 
   String toLocale(BuildContext context) => switch (this) {
         MangaSort.alphabetical => context.l10n.mangaSortAlphabetical,
         MangaSort.dateAdded => context.l10n.mangaSortDateAdded,
         MangaSort.unread => context.l10n.mangaSortUnread,
         MangaSort.lastUpdated => context.l10n.mangaSortLastUpdated,
+        MangaSort.lastRead => context.l10n.mangaSortLastRead,
       };
 }
 

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -83,8 +83,10 @@ class CategoryMangaListWithQueryAndFilter
                       int.tryParse(m2.latestFetchedChapter?.fetchedAt ?? '0') ??
                           0),
             MangaSort.lastRead =>
-              (m2.lastReadChapter?.lastReadAt ?? 0)
-                  .compareTo(m1.lastReadChapter?.lastReadAt ?? 0),
+              (int.tryParse(m2.lastReadChapter?.lastReadAt ?? '0') ?? 0)
+                  .compareTo(
+                      int.tryParse(m1.lastReadChapter?.lastReadAt ?? '0') ??
+                          0),
           }) *
           sortDirToggle;
     }

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -82,6 +82,9 @@ class CategoryMangaListWithQueryAndFilter
                   .compareTo(
                       int.tryParse(m2.latestFetchedChapter?.fetchedAt ?? '0') ??
                           0),
+            MangaSort.lastRead =>
+              (m2.lastReadChapter?.lastReadAt ?? 0)
+                  .compareTo(m1.lastReadChapter?.lastReadAt ?? 0),
           }) *
           sortDirToggle;
     }


### PR DESCRIPTION
## What

Adds a **Sort by Last Read** option to the library manga organizer. Users can now sort their library by when they last read a manga.

## Why

Makes it easy to continue reading from where you last left off, or push manga you have not touched recently to the bottom.

## Changes

- `lib/src/constants/enum.dart` - added `lastRead` to `MangaSort` enum
- `lib/src/features/library/presentation/library/controller/library_controller.dart` - added `lastRead` sort case using `lastReadChapter?.lastReadAt` from the GraphQL model

Ported from tachimanga/Tachidesk-Sorayomi commits 03eb0b1 and c3ebde0, adapted for the GraphQL-based model.
