### PR TITLE
Fix tri-state filter tile so "no filter" actually means "no filter"

### DIFF
--- a/lib/src/widgets/custom_checkbox_list_tile.dart
+++ b/lib/src/widgets/custom_checkbox_list_tile.dart
@@ -10,6 +10,17 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../utils/extensions/custom_extensions.dart';
 
+/// Tri-state filter tile used across the library and chapter filter sheets.
+///
+/// Tristate cycle on tap: `null` (ignore) → `true` (include / require) →
+/// `false` (exclude) → `null`. This matches the convention users carry over
+/// from Mihon, Komikku, and Tachiyomi, where the default empty state means
+/// "do not filter" and the two active states clearly distinguish include
+/// from exclude with different icons.
+///
+/// In binary mode (`tristate: false`) the widget falls back to Flutter's
+/// `CheckboxListTile`, which is what existing display-preference callers
+/// (e.g. badge toggles) rely on.
 class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
     extends ConsumerWidget {
   const CustomCheckboxListTile({
@@ -23,16 +34,45 @@ class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
   final AutoDisposeNotifierProvider<NotifierT, bool?> provider;
   final ValueChanged<bool?> onChanged;
   final bool tristate;
+
+  static bool? _nextValue(bool? current) {
+    if (current == null) return true;
+    if (current == true) return false;
+    return null;
+  }
+
+  Widget _tristateLeading(BuildContext context, bool? value) {
+    final activeColor = context.theme.indicatorColor;
+    final excludeColor = context.theme.colorScheme.error;
+    if (value == null) {
+      return Icon(
+        Icons.check_box_outline_blank_rounded,
+        color: context.theme.unselectedWidgetColor,
+      );
+    } else if (value == true) {
+      return Icon(Icons.check_box_rounded, color: activeColor);
+    } else {
+      return Icon(Icons.disabled_by_default_rounded, color: excludeColor);
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final val = ref.watch(provider);
-    return CheckboxListTile(
-      controlAffinity: ListTileControlAffinity.leading,
-      activeColor: context.theme.indicatorColor,
-      value: tristate ? val : val.ifNull(true),
+    if (!tristate) {
+      return CheckboxListTile(
+        controlAffinity: ListTileControlAffinity.leading,
+        activeColor: context.theme.indicatorColor,
+        value: val.ifNull(true),
+        title: Text(title),
+        tristate: false,
+        onChanged: onChanged,
+      );
+    }
+    return ListTile(
+      leading: _tristateLeading(context, val),
       title: Text(title),
-      tristate: tristate,
-      onChanged: onChanged,
+      onTap: () => onChanged(_nextValue(val)),
     );
   }
 }


### PR DESCRIPTION
## The bug

Library filter tiles (Downloaded, Unread, Bookmarked, etc.) are tri-state: they should cycle no-filter → include → exclude. The current implementation wraps Flutter's `CheckboxListTile(tristate: true)`, which causes two problems:

1. **Wrong tap cycle.** Flutter's cycle is `false → true → null → false`. A fresh filter tile is `null` (no filter), so the first tap moves it to `false` — silently flipping the filter into **exclude** instead of include.
2. **Indistinguishable visuals.** `null` renders as a dash, `false` renders as an empty box. Users read empty-box as "no filter set" but it's actually excluding.

Combined effect: tapping a few filters intuitively can hide most of the library without the user realizing why.

## The fix

Replace the wrapper for tri-state callers with a `ListTile` + custom icon leading. Correct cycle: `null` (no filter) → `true` (include) → `false` (exclude) → `null`. Three visually distinct icons:

- empty checkbox = no filter
- filled check = include
- filled X in error color = exclude

Binary callers (`tristate: false`, e.g. display-preference badge toggles) keep the existing `CheckboxListTile` path so nothing else changes.

## Parity

Matches the filter convention from **Mihon, Komikku, and Tachiyomi** — empty state always means "do not filter," include and exclude are visually obvious. Users coming from those readers expect this affordance.

## Test plan

- Open Library → Filter sheet, verify each filter starts at no-filter (empty box).
- Tap once → include (filled check). Tap again → exclude (red X). Tap third → back to no-filter.
- Same in the Chapter filter sheet.
- Display-preference toggles (Downloaded badge, Unread badge) still behave as binary checkboxes.