### PR TITLE
Fix webtoon chapter not marked as read when last image is shorter than viewport

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
@@ -97,7 +97,12 @@ class ContinuousReaderMode extends HookConsumerWidget {
         // Don't update position if we're navigating from slider
         if (!isNavigatingFromSlider.value) {
           // Always update position for UI display (navigation bar needs this)
-          _updatePositionForDisplay(positions, currentIndex, lastReportedIndex);
+          _updatePositionForDisplay(
+            positions,
+            currentIndex,
+            lastReportedIndex,
+            chapterPages.chapter.pageCount,
+          );
         }
 
         // Mark as user scrolling to prevent programmatic navigation
@@ -259,8 +264,26 @@ class ContinuousReaderMode extends HookConsumerWidget {
     List<ItemPosition> positions,
     ValueNotifier<int> currentIndex,
     ValueNotifier<int> lastReportedIndex,
+    int itemCount,
   ) {
     if (positions.isEmpty) return;
+
+    // When the last image is shorter than the viewport, the "most visible
+    // area" heuristic below can pick a larger image above instead of the
+    // last image, so currentIndex never reaches the end of the chapter and
+    // mark-as-read never fires. If the last item is in view and the scroll
+    // has reached its end (the last item's trailing edge is at or above
+    // the viewport bottom), force currentIndex to the last page so the
+    // read-marking pipeline downstream behaves correctly.
+    if (itemCount > 0) {
+      final int lastIndex = itemCount - 1;
+      for (final ItemPosition position in positions) {
+        if (position.index == lastIndex && position.itemTrailingEdge <= 1.0) {
+          currentIndex.value = lastIndex;
+          return;
+        }
+      }
+    }
 
     // Find the item that's most visible for display purposes
     ItemPosition? mostVisible;


### PR DESCRIPTION
Closes #296.

## The reported bug

From #296: in webtoon mode, scrolling to the very end of a chapter does NOT mark it as read when the last image is shorter than the viewport. The chapter stays stuck at e.g. "22/23 read" even after the user has clearly scrolled past the end.

## Why it happens

The continuous reader's position tracker picks the page with the **largest visible area** in the viewport to drive `currentIndex`. When the last image is shorter than the viewport, a larger image above it still wins the area contest, so `currentIndex` never reaches the final page — and the mark-as-read pipeline in `reader_screen` only fires when `currentIndex == pageCount - 1`.

## The fix

Special-case the bottom of the chapter: if the last item is in view AND the scroll has reached its end (the last item's trailing edge is at or above the viewport bottom), force `currentIndex` to that last index before falling through to the area-based heuristic.

No new state, no provider changes — just a single conditional in the position-listener path.

## Test plan

- Open a webtoon-mode chapter where the last image is significantly shorter than the device's viewport (common with author endnotes / single-line cover at chapter end).
- Scroll to the bottom.
- Verify the chapter is now marked as read (full "Read" state, page indicator at N/N).
- Verify that chapters where every page fills the viewport (the common case) still mark as read normally — no regression in the area-based heuristic path.
- Verify in single-page reader mode that mark-as-read still works as before (this change only touches the continuous reader).