### PR TITLE
Library sort/filter parity: Last Chapter Date + Total Chapters sorts; Started + Bookmarked filters

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -37,6 +37,8 @@ enum DBKeys {
   mangaFilterDownloaded(null),
   mangaFilterUnread(null),
   mangaFilterCompleted(null),
+  mangaFilterStarted(null),
+  mangaFilterBookmarked(null),
   chapterFilterDownloaded(null),
   chapterFilterUnread(null),
   chapterFilterBookmarked(null),

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -74,13 +74,17 @@ enum MangaSort {
   alphabetical,
   dateAdded,
   unread,
-  lastUpdated;
+  lastUpdated,
+  lastChapterDate,
+  totalChapters;
 
   String toLocale(BuildContext context) => switch (this) {
         MangaSort.alphabetical => context.l10n.mangaSortAlphabetical,
         MangaSort.dateAdded => context.l10n.mangaSortDateAdded,
         MangaSort.unread => context.l10n.mangaSortUnread,
         MangaSort.lastUpdated => context.l10n.mangaSortLastUpdated,
+        MangaSort.lastChapterDate => context.l10n.mangaSortLastChapterDate,
+        MangaSort.totalChapters => context.l10n.mangaSortTotalChapters,
       };
 }
 

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -82,6 +82,14 @@ class CategoryMangaListWithQueryAndFilter
                   .compareTo(
                       int.tryParse(m2.latestFetchedChapter?.fetchedAt ?? '0') ??
                           0),
+            MangaSort.lastChapterDate => (int.tryParse(
+                        m1.latestUploadedChapter?.uploadDate ?? '0') ??
+                    0)
+                .compareTo(
+                    int.tryParse(m2.latestUploadedChapter?.uploadDate ?? '0') ??
+                        0),
+            MangaSort.totalChapters => m1.chapters.totalCount
+                .compareTo(m2.chapters.totalCount),
           }) *
           sortDirToggle;
     }

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -41,6 +41,9 @@ class CategoryMangaListWithQueryAndFilter
     final mangaFilterDownloaded =
         ref.watch(libraryMangaFilterDownloadedProvider);
     final mangaFilterCompleted = ref.watch(libraryMangaFilterCompletedProvider);
+    final mangaFilterStarted = ref.watch(libraryMangaFilterStartedProvider);
+    final mangaFilterBookmarked =
+        ref.watch(libraryMangaFilterBookmarkedProvider);
     final MangaSort sortedBy =
         ref.watch(libraryMangaSortProvider) ?? DBKeys.mangaSort.initial;
     final sortedDirection =
@@ -59,6 +62,16 @@ class CategoryMangaListWithQueryAndFilter
 
       if (mangaFilterCompleted != null &&
           (mangaFilterCompleted ^ (manga.status.name == "COMPLETED"))) {
+        return false;
+      }
+
+      if (mangaFilterStarted != null &&
+          (mangaFilterStarted ^ (manga.lastReadChapter != null))) {
+        return false;
+      }
+
+      if (mangaFilterBookmarked != null &&
+          (mangaFilterBookmarked ^ manga.bookmarkCount.isGreaterThan(0))) {
         return false;
       }
 
@@ -130,6 +143,20 @@ class LibraryMangaFilterCompleted extends _$LibraryMangaFilterCompleted
     with SharedPreferenceClientMixin<bool> {
   @override
   bool? build() => initialize(DBKeys.mangaFilterCompleted);
+}
+
+@riverpod
+class LibraryMangaFilterStarted extends _$LibraryMangaFilterStarted
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.mangaFilterStarted);
+}
+
+@riverpod
+class LibraryMangaFilterBookmarked extends _$LibraryMangaFilterBookmarked
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.mangaFilterBookmarked);
 }
 
 @riverpod

--- a/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
@@ -24,10 +24,22 @@ class LibraryMangaFilter extends ConsumerWidget {
           onChanged: ref.read(libraryMangaFilterUnreadProvider.notifier).update,
         ),
         CustomCheckboxListTile(
+          title: context.l10n.started,
+          provider: libraryMangaFilterStartedProvider,
+          onChanged:
+              ref.read(libraryMangaFilterStartedProvider.notifier).update,
+        ),
+        CustomCheckboxListTile(
           title: context.l10n.completed,
           provider: libraryMangaFilterCompletedProvider,
           onChanged:
               ref.read(libraryMangaFilterCompletedProvider.notifier).update,
+        ),
+        CustomCheckboxListTile(
+          title: context.l10n.bookmarked,
+          provider: libraryMangaFilterBookmarkedProvider,
+          onChanged:
+              ref.read(libraryMangaFilterBookmarkedProvider.notifier).update,
         ),
         CustomCheckboxListTile(
           title: context.l10n.downloaded,

--- a/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
+++ b/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
@@ -2,6 +2,10 @@ fragment MangaDto on MangaType {
   age
   artist
   author
+  bookmarkCount
+  chapters {
+    totalCount
+  }
   chaptersAge
   chaptersLastFetchedAt
   description

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -408,11 +408,17 @@
     "@mangaSortDateAdded": {
         "description": "Radio button text for Manga sort Type - Date Added"
     },
+    "@mangaSortLastChapterDate": {
+        "description": "Radio button text for Manga sort Type - Last Chapter Date (upload date of the most recent chapter from the source)"
+    },
     "@mangaSortLastRead": {
         "description": "Radio button text for Manga sort Type - Last Read"
     },
     "@mangaSortLastUpdated": {
         "description": "Radio button text for Manga sort Type - Last Updated"
+    },
+    "@mangaSortTotalChapters": {
+        "description": "Radio button text for Manga sort Type - Total Chapters"
     },
     "@mangaSortUnread": {
         "description": "Radio button text for Manga sort Type - Unread"
@@ -1070,8 +1076,10 @@
     "mangaMissingSources": "Manga Missing Sources",
     "mangaSortAlphabetical": "Alphabetical",
     "mangaSortDateAdded": "Date Added",
+    "mangaSortLastChapterDate": "Last Chapter Date",
     "mangaSortLastRead": "Last Read",
     "mangaSortLastUpdated": "Last Updated",
+    "mangaSortTotalChapters": "Total Chapters",
     "mangaSortUnread": "Unread",
     "mangaStatusCancelled": "Cancelled",
     "mangaStatusCompleted": "Completed",

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -850,6 +850,9 @@
     "@start": {
         "description": "Button text start reading the manga"
     },
+    "@started": {
+        "description": "Library filter label: manga the user has started reading (read at least one chapter)"
+    },
     "@systemTrayIcon": {
         "description": "Switch title to Show icon in system tray in settings"
     },
@@ -1289,6 +1292,7 @@
     "sourceTypePopular": "Popular",
     "sources": "Sources",
     "start": "Start",
+    "started": "Started",
     "systemTrayIcon": "Show icon in system tray",
     "thatHaventBeenStarted": "That haven't been started",
     "themeModeDark": "Dark",

--- a/lib/src/widgets/custom_checkbox_list_tile.dart
+++ b/lib/src/widgets/custom_checkbox_list_tile.dart
@@ -10,6 +10,17 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../utils/extensions/custom_extensions.dart';
 
+/// Tri-state filter tile used across the library and chapter filter sheets.
+///
+/// Tristate cycle on tap: `null` (ignore) → `true` (include / require) →
+/// `false` (exclude) → `null`. This matches the convention users carry over
+/// from Mihon, Komikku, and Tachiyomi, where the default empty state means
+/// "do not filter" and the two active states clearly distinguish include
+/// from exclude with different icons.
+///
+/// In binary mode (`tristate: false`) the widget falls back to Flutter's
+/// `CheckboxListTile`, which is what existing display-preference callers
+/// (e.g. badge toggles) rely on.
 class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
     extends ConsumerWidget {
   const CustomCheckboxListTile({
@@ -23,16 +34,45 @@ class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
   final AutoDisposeNotifierProvider<NotifierT, bool?> provider;
   final ValueChanged<bool?> onChanged;
   final bool tristate;
+
+  static bool? _nextValue(bool? current) {
+    if (current == null) return true;
+    if (current == true) return false;
+    return null;
+  }
+
+  Widget _tristateLeading(BuildContext context, bool? value) {
+    final activeColor = context.theme.indicatorColor;
+    final excludeColor = context.theme.colorScheme.error;
+    if (value == null) {
+      return Icon(
+        Icons.check_box_outline_blank_rounded,
+        color: context.theme.unselectedWidgetColor,
+      );
+    } else if (value == true) {
+      return Icon(Icons.check_box_rounded, color: activeColor);
+    } else {
+      return Icon(Icons.disabled_by_default_rounded, color: excludeColor);
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final val = ref.watch(provider);
-    return CheckboxListTile(
-      controlAffinity: ListTileControlAffinity.leading,
-      activeColor: context.theme.indicatorColor,
-      value: tristate ? val : val.ifNull(true),
+    if (!tristate) {
+      return CheckboxListTile(
+        controlAffinity: ListTileControlAffinity.leading,
+        activeColor: context.theme.indicatorColor,
+        value: val.ifNull(true),
+        title: Text(title),
+        tristate: false,
+        onChanged: onChanged,
+      );
+    }
+    return ListTile(
+      leading: _tristateLeading(context, val),
       title: Text(title),
-      tristate: tristate,
-      onChanged: onChanged,
+      onTap: () => onChanged(_nextValue(val)),
     );
   }
 }


### PR DESCRIPTION
Closes #246 (Sort library by last chapter date).

**Depends on #374 (tri-state filter fix).** Merge that first — the new filters use the tristate tile widget that #374 replaces, and visual/behavioral consistency depends on it. The branch is stacked on top of `fix/tri-state-filter-ux`, so the diff currently includes that commit; if #374 lands first, this PR rebases cleanly.

## What this adds

### Sorts
- **Last Chapter Date** — sorts by `latestUploadedChapter.uploadDate` (a server field already exposed in Suwayomi v1.0.0). Closes #246.
- **Total Chapters** — sorts by `manga.chapters.totalCount`. Useful for spotting unusually short or long series at a glance.

### Filters (tri-state)
- **Started** — `lastReadChapter != null`. Surfaces manga the user has read at least one chapter of.
- **Bookmarked** — `bookmarkCount > 0`. Surfaces manga where the user has saved specific chapters for later.

Both follow the existing tri-state pattern: null = ignore, true = require, false = exclude.

## Why

The Suwayomi server already exposes all of these fields (`bookmarkCount`, `chapters.totalCount`, `latestUploadedChapter.uploadDate`), and Suwayomi-WebUI already surfaces them. Sorayomi just hasn't caught up. This PR closes the gap on the Flutter client.

## Implementation notes

- One MangaDto fragment expansion (`bookmarkCount` + `chapters.totalCount`) to make the data available client-side.
- Filter tile ordering follows the conventional reading-state progression: **unread → started → completed**, then **bookmarked**, then **downloaded**.
- No server-side changes required; both new fields are already returned by Suwayomi v1.0.0+.

## Test plan

- Library → Sort sheet → "Last Chapter Date" and "Total Chapters" appear. Apply each, library reorders correctly. Ascending/descending toggle works.
- Library → Filter sheet → "Started" and "Bookmarked" tiles appear in the order above. For each, cycle no-filter → include → exclude, library filters correctly.
- A manga with bookmarked chapters shows up under Bookmarked-include; a manga with no read history is excluded under Started-include; etc.
- Existing sorts and filters (Unread, Downloaded, Completed) unchanged.