### PR TITLE
Fix two-finger pinch-to-zoom in reader modes (#256)

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import '../../../../../constants/enum.dart';
 import '../../../../../routes/router_config.dart';
+import '../../../../../widgets/zoom/single_touch_drag_recognizers.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/chapter_page/chapter_page_model.dart';
 import '../utils/last_page_swipe_utils.dart';
@@ -57,60 +58,90 @@ class DirectionalSwipeGestureHandler extends HookWidget {
   Widget build(BuildContext context) {
     final bool useAdvancedGestures =
         lastPageSwipeEnabled && !readerSwipeChapterToggle;
-
-    if (useAdvancedGestures) {
-      return _buildAdvancedGestureHandler(context);
-    } else {
-      return _buildSimpleGestureHandler(context);
-    }
+    return useAdvancedGestures
+        ? _buildAdvancedGestureHandler(context)
+        : _buildSimpleGestureHandler(context);
   }
 
-  /// Advanced gesture handler using RawGestureDetector for proper arena competition
+  /// Advanced gesture handler — single-touch pan recognizer for swipe-at-
+  /// last-page; tap + long-press in a nested GestureDetector (those don't
+  /// fight multi-touch).
   Widget _buildAdvancedGestureHandler(BuildContext context) {
-    return GestureDetector(
-      onLongPressStart: onLongPressStart,
-      onLongPressEnd: onLongPressEnd,
-      onLongPressMoveUpdate: onLongPressMoveUpdate,
-      onTap: onTap,
+    return RawGestureDetector(
       behavior: HitTestBehavior.translucent,
-      onPanEnd: (details) {
-        final swipeDirection = LastPageSwipeUtils.detectSwipeDirection(details);
-
-        if (swipeDirection != null) {
-          _handleAdvancedSwipeGesture(
-            context: context,
-            direction: swipeDirection,
-            details: details,
-          );
-        }
+      gestures: <Type, GestureRecognizerFactory>{
+        SingleTouchPanGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<SingleTouchPanGestureRecognizer>(
+          () => SingleTouchPanGestureRecognizer(debugOwner: this),
+          (recognizer) {
+            recognizer.onEnd = (details) {
+              final swipeDirection =
+                  LastPageSwipeUtils.detectSwipeDirection(details);
+              if (swipeDirection != null) {
+                _handleAdvancedSwipeGesture(
+                  context: context,
+                  direction: swipeDirection,
+                  details: details,
+                );
+              }
+            };
+          },
+        ),
       },
-      child: child,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onLongPressStart: onLongPressStart,
+        onLongPressEnd: onLongPressEnd,
+        onLongPressMoveUpdate: onLongPressMoveUpdate,
+        onTap: onTap,
+        child: child,
+      ),
     );
   }
 
-  /// Simple gesture handler as fallback
+  /// Simple gesture handler — single-touch horizontal + vertical drag
+  /// recognizers for swipe-at-chapter-boundary; tap + long-press nested.
   Widget _buildSimpleGestureHandler(BuildContext context) {
-    return GestureDetector(
-      onLongPressStart: onLongPressStart,
-      onLongPressEnd: onLongPressEnd,
-      onLongPressMoveUpdate: onLongPressMoveUpdate,
-      onTap: onTap,
+    return RawGestureDetector(
       behavior: HitTestBehavior.translucent,
-      onHorizontalDragEnd: (details) {
-        _handleSwipeGesture(
-          context: context,
-          details: details,
-          allowedAxis: Axis.vertical,
-        );
+      gestures: <Type, GestureRecognizerFactory>{
+        SingleTouchHorizontalDragGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<
+                SingleTouchHorizontalDragGestureRecognizer>(
+          () => SingleTouchHorizontalDragGestureRecognizer(debugOwner: this),
+          (recognizer) {
+            recognizer.onEnd = (details) {
+              _handleSwipeGesture(
+                context: context,
+                details: details,
+                allowedAxis: Axis.vertical,
+              );
+            };
+          },
+        ),
+        SingleTouchVerticalDragGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<
+                SingleTouchVerticalDragGestureRecognizer>(
+          () => SingleTouchVerticalDragGestureRecognizer(debugOwner: this),
+          (recognizer) {
+            recognizer.onEnd = (details) {
+              _handleSwipeGesture(
+                context: context,
+                details: details,
+                allowedAxis: Axis.horizontal,
+              );
+            };
+          },
+        ),
       },
-      onVerticalDragEnd: (details) {
-        _handleSwipeGesture(
-          context: context,
-          details: details,
-          allowedAxis: Axis.horizontal,
-        );
-      },
-      child: child,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onLongPressStart: onLongPressStart,
+        onLongPressEnd: onLongPressEnd,
+        onLongPressMoveUpdate: onLongPressMoveUpdate,
+        onTap: onTap,
+        child: child,
+      ),
     );
   }
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
@@ -13,10 +13,12 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:zoom_view/zoom_view.dart';
 
 import '../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../utils/misc/app_utils.dart';
 import '../../../../../../widgets/server_image.dart';
+import '../../../../../../widgets/zoom/scroll_offset_to_scroll_controller.dart';
 import '../../../../../settings/presentation/reader/widgets/reader_pinch_to_zoom/reader_pinch_to_zoom.dart';
 import '../../../../../settings/presentation/reader/widgets/reader_scroll_animation_tile/reader_scroll_animation_tile.dart';
 import '../../../../domain/chapter/chapter_model.dart';
@@ -65,6 +67,14 @@ class ContinuousReaderMode extends HookConsumerWidget {
         useMemoized(() => ItemScrollController());
     final ItemPositionsListener positionsListener =
         useMemoized(() => ItemPositionsListener.create());
+    final ScrollOffsetController scrollOffsetController =
+        useMemoized(() => ScrollOffsetController());
+    final ScrollController zoomScrollController = useMemoized(
+      () => ScrollOffsetToScrollController(
+        scrollOffsetController: scrollOffsetController,
+      ),
+      [scrollOffsetController],
+    );
 
     final ValueNotifier<int> currentIndex = useState(
       chapter.isRead.ifNull()
@@ -184,11 +194,22 @@ class ContinuousReaderMode extends HookConsumerWidget {
         !kIsWeb &&
                 (Platform.isAndroid || Platform.isIOS) &&
                 isPinchToZoomEnabled
-            ? (Widget child) => InteractiveViewer(maxScale: 5, child: child)
+            ? (Widget child) => ZoomView(
+                  controller: zoomScrollController,
+                  scrollAxis: scrollDirection,
+                  maxScale: 5,
+                  doubleTapDrag: true,
+                  // Required so the scale recognizer wins the gesture
+                  // arena against the underlying scrollable's drag
+                  // recognizer (closes #256).
+                  forceHoldOnPointerDown: true,
+                  child: child,
+                )
             : null,
         ScrollablePositionedList.separated(
           itemScrollController: scrollController,
           itemPositionsListener: positionsListener,
+          scrollOffsetController: scrollOffsetController,
           initialScrollIndex: chapter.isRead.ifNull()
               ? 0
               : chapter.lastPageRead.getValueOnNullOrNegative(),

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:zoom_view/zoom_view.dart';
 
 import '../../../../../../constants/app_constants.dart';
 import '../../../../../../utils/extensions/cache_manager_extensions.dart';
@@ -110,47 +111,56 @@ class SinglePageReaderMode extends HookConsumerWidget {
         curve: kCurve,
       ),
       pageController: scrollController,
-      child: PageView.builder(
-        scrollDirection: scrollDirection,
-        reverse: reverse,
-        controller: scrollController,
-        allowImplicitScrolling: true,
-        physics: const BouncingScrollPhysics(
-            parent: AlwaysScrollableScrollPhysics()),
-        itemBuilder: (BuildContext context, int index) {
-          // Show loading indicator if no pages are available yet
-          if (chapterPages.pages.isEmpty) {
-            return const Center(
-              child: CenterSorayomiShimmerIndicator(),
-            );
-          }
+      child: AppUtils.wrapOn(
+        !kIsWeb && (Platform.isAndroid || Platform.isIOS)
+            ? (Widget child) => ZoomView(
+                  controller: scrollController,
+                  scrollAxis: scrollDirection,
+                  maxScale: 5,
+                  doubleTapDrag: true,
+                  // Required so the scale recognizer wins the gesture
+                  // arena against the underlying PageView's pan
+                  // recognizer (closes #256).
+                  forceHoldOnPointerDown: true,
+                  child: child,
+                )
+            : null,
+        PageView.builder(
+          scrollDirection: scrollDirection,
+          reverse: reverse,
+          controller: scrollController,
+          allowImplicitScrolling: true,
+          physics: const BouncingScrollPhysics(
+              parent: AlwaysScrollableScrollPhysics()),
+          itemBuilder: (BuildContext context, int index) {
+            // Show loading indicator if no pages are available yet
+            if (chapterPages.pages.isEmpty) {
+              return const Center(
+                child: CenterSorayomiShimmerIndicator(),
+              );
+            }
 
-          // Add bounds checking to prevent accessing non-existent pages
-          if (index >= chapterPages.pages.length) {
-            return const Center(
-              child: CenterSorayomiShimmerIndicator(),
-            );
-          }
+            // Add bounds checking to prevent accessing non-existent pages
+            if (index >= chapterPages.pages.length) {
+              return const Center(
+                child: CenterSorayomiShimmerIndicator(),
+              );
+            }
 
-          final image = ServerImage(
-            showReloadButton: true,
-            fit: BoxFit.contain,
-            size: Size.fromHeight(context.height),
-            appendApiToUrl: false,
-            imageUrl: chapterPages.pages[index],
-            progressIndicatorBuilder: (context, url, downloadProgress) =>
-                CenterSorayomiShimmerIndicator(
-              value: downloadProgress.progress,
-            ),
-          );
-          return AppUtils.wrapOn(
-            !kIsWeb && (Platform.isAndroid || Platform.isIOS)
-                ? (child) => InteractiveViewer(maxScale: 5, child: child)
-                : null,
-            image,
-          );
-        },
-        itemCount: chapterPages.pages.isEmpty ? 1 : chapterPages.pages.length,
+            return ServerImage(
+              showReloadButton: true,
+              fit: BoxFit.contain,
+              size: Size.fromHeight(context.height),
+              appendApiToUrl: false,
+              imageUrl: chapterPages.pages[index],
+              progressIndicatorBuilder: (context, url, downloadProgress) =>
+                  CenterSorayomiShimmerIndicator(
+                value: downloadProgress.progress,
+              ),
+            );
+          },
+          itemCount: chapterPages.pages.isEmpty ? 1 : chapterPages.pages.length,
+        ),
       ),
     );
   }

--- a/lib/src/widgets/zoom/scroll_offset_to_scroll_controller.dart
+++ b/lib/src/widgets/zoom/scroll_offset_to_scroll_controller.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Adapter that exposes a `ScrollablePositionedList.scrollOffsetController` as
+// a standard `ScrollController`. Required by `zoom_view`, which needs a
+// `ScrollController` to coordinate scroll position with pinch-zoom but
+// `ScrollablePositionedList` only exposes `ScrollOffsetController`.
+//
+// Depends on the `position` getter that yakagami's fork of
+// scrollable_positioned_list adds to `ScrollOffsetController` — see the
+// pubspec comment on that dependency.
+
+import 'package:flutter/material.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+class ScrollOffsetToScrollController extends ScrollController {
+  ScrollOffsetToScrollController({required this.scrollOffsetController});
+
+  final ScrollOffsetController scrollOffsetController;
+
+  @override
+  ScrollPosition get position => scrollOffsetController.position;
+
+  @override
+  void jumpTo(double value) {
+    // ScrollOffsetController doesn't expose a public jumpTo; go through the
+    // underlying ScrollPosition directly (which the fork makes available).
+    scrollOffsetController.position.jumpTo(value);
+  }
+
+  @override
+  Future<void> animateTo(
+    double offset, {
+    required Curve curve,
+    required Duration duration,
+  }) {
+    // ScrollOffsetController.animateScroll takes a RELATIVE offset (from
+    // current pixels); translate the absolute target ScrollController users
+    // pass in.
+    final delta = offset - scrollOffsetController.position.pixels;
+    return scrollOffsetController.animateScroll(
+      offset: delta,
+      duration: duration,
+      curve: curve,
+    );
+  }
+}

--- a/lib/src/widgets/zoom/single_touch_drag_recognizers.dart
+++ b/lib/src/widgets/zoom/single_touch_drag_recognizers.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Drag gesture recognizers that refuse to claim multi-touch gestures.
+//
+// Flutter's stock `HorizontalDragGestureRecognizer` / `VerticalDragGestureRecognizer`
+// happily accept the gesture arena even when a second finger is already on
+// screen. Inside the reader, that means a two-finger pinch is silently
+// stolen from `ZoomView`'s scale recognizer as soon as either finger drifts
+// past drag slop — which is the root cause of upstream #256 ("two-finger
+// pinch is almost unusable").
+//
+// These subclasses track the pointers they personally see. When a second
+// pointer arrives, the recognizer rejects its in-flight gesture for the
+// first pointer (via `resolve(rejected)`) and does not track the second
+// pointer at all. Net effect in the gesture arena: single-finger drags
+// still drive `DirectionalSwipeGestureHandler`'s swipe-at-chapter-boundary
+// navigation; two-finger gestures fall through to `ZoomView` cleanly.
+//
+// Self-tracking is used rather than a globally shared counter because
+// pointer-down events reach the gesture recognizer BEFORE they reach an
+// outer `Listener` widget in Flutter's hit-test order, so a Listener-
+// maintained count would always be stale by one event.
+
+import 'package:flutter/gestures.dart';
+
+class SingleTouchHorizontalDragGestureRecognizer
+    extends HorizontalDragGestureRecognizer {
+  SingleTouchHorizontalDragGestureRecognizer({super.debugOwner});
+
+  final Set<int> _selfTracked = <int>{};
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    if (_selfTracked.isNotEmpty) {
+      _selfTracked.clear();
+      resolve(GestureDisposition.rejected);
+      return;
+    }
+    _selfTracked.add(event.pointer);
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    _selfTracked.remove(pointer);
+    super.didStopTrackingLastPointer(pointer);
+  }
+}
+
+class SingleTouchVerticalDragGestureRecognizer
+    extends VerticalDragGestureRecognizer {
+  SingleTouchVerticalDragGestureRecognizer({super.debugOwner});
+
+  final Set<int> _selfTracked = <int>{};
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    if (_selfTracked.isNotEmpty) {
+      _selfTracked.clear();
+      resolve(GestureDisposition.rejected);
+      return;
+    }
+    _selfTracked.add(event.pointer);
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    _selfTracked.remove(pointer);
+    super.didStopTrackingLastPointer(pointer);
+  }
+}
+
+class SingleTouchPanGestureRecognizer extends PanGestureRecognizer {
+  SingleTouchPanGestureRecognizer({super.debugOwner});
+
+  final Set<int> _selfTracked = <int>{};
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    if (_selfTracked.isNotEmpty) {
+      _selfTracked.clear();
+      resolve(GestureDisposition.rejected);
+      return;
+    }
+    _selfTracked.add(event.pointer);
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    _selfTracked.remove(pointer);
+    super.didStopTrackingLastPointer(pointer);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1190,11 +1190,12 @@ packages:
   scrollable_positioned_list:
     dependency: "direct main"
     description:
-      name: scrollable_positioned_list
-      sha256: "1b54d5f1329a1e263269abc9e2543d90806131aa14fe7c6062a8054d57249287"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.8"
+      path: "."
+      ref: "4641e83"
+      resolved-ref: "4641e83784aa852f131d543f79c63663f55e606f"
+      url: "https://github.com/yakagami/scrollable_positioned_list"
+    source: git
+    version: "0.3.8+1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1624,6 +1625,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  zoom_view:
+    dependency: "direct main"
+    description:
+      name: zoom_view
+      sha256: d2c75e32382c45d4e6a9d1c217d3478610d77ec4039d88c69c03e574d7899438
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,11 +49,21 @@ dependencies:
   pub_semver: ^2.1.2
   queue: ^3.1.0+2
   riverpod_annotation: ^2.0.0
-  scrollable_positioned_list: ^0.3.5
+  # Pinned to yakagami's fork (2-line addition over upstream) which exposes
+  # ScrollPosition on ScrollOffsetController. Required for zoom_view to
+  # coordinate scroll position with pinch-zoom in the multi-image readers.
+  # Tracking upstream merge of the same fix at:
+  #   https://github.com/google/flutter.widgets/pull/535
+  # Revert to a pub.dev release once that lands.
+  scrollable_positioned_list:
+    git:
+      url: https://github.com/yakagami/scrollable_positioned_list
+      ref: "4641e83"
   shared_preferences: ^2.0.15
   shimmer: ^3.0.0
   url_launcher: ^6.1.6
   web_socket_channel: ^3.0.0
+  zoom_view: ^1.0.2
 
 dev_dependencies:
   build_runner: ^2.4.14

--- a/test/src/widgets/zoom/single_touch_drag_recognizers_test.dart
+++ b/test/src/widgets/zoom/single_touch_drag_recognizers_test.dart
@@ -1,0 +1,166 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Tests for the single-touch drag recognizers used by
+// DirectionalSwipeGestureHandler. The whole point of the subclasses is that
+// they refuse to claim multi-touch gestures, so a two-finger pinch can fall
+// through to ZoomView's scale recognizer.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tachidesk_sorayomi/src/widgets/zoom/single_touch_drag_recognizers.dart';
+
+const double _viewportWidth = 400.0;
+const double _viewportHeight = 800.0;
+
+const _testKey = ValueKey('test-drag-target');
+
+Future<void> _pumpWithSingleTouchRecognizer(
+  WidgetTester tester, {
+  required void Function(DragEndDetails) onHorizontalDragEnd,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(_viewportWidth, _viewportHeight);
+  addTearDown(() {
+    tester.view.resetDevicePixelRatio();
+    tester.view.resetPhysicalSize();
+  });
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: _viewportWidth,
+          height: _viewportHeight,
+          child: RawGestureDetector(
+              key: _testKey,
+              behavior: HitTestBehavior.translucent,
+              gestures: <Type, GestureRecognizerFactory>{
+                SingleTouchHorizontalDragGestureRecognizer:
+                    GestureRecognizerFactoryWithHandlers<
+                        SingleTouchHorizontalDragGestureRecognizer>(
+                  () => SingleTouchHorizontalDragGestureRecognizer(),
+                  (recognizer) {
+                    recognizer.onEnd = onHorizontalDragEnd;
+                  },
+                ),
+                // A scale recognizer is included to keep the gesture
+                // arena from eagerly accepting our drag recognizer on the
+                // first pointer down. In the real reader, ZoomView's
+                // scale recognizer plays this role.
+                ScaleGestureRecognizer:
+                    GestureRecognizerFactoryWithHandlers<
+                        ScaleGestureRecognizer>(
+                  () => ScaleGestureRecognizer(),
+                  (recognizer) {
+                    // No-op handlers; just need it in the arena.
+                    recognizer.onStart = (_) {};
+                    recognizer.onUpdate = (_) {};
+                    recognizer.onEnd = (_) {};
+                  },
+                ),
+              },
+            child: const SizedBox.expand(
+              child: ColoredBox(color: Colors.transparent),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('SingleTouchHorizontalDragGestureRecognizer', () {
+    testWidgets(
+        'single-finger horizontal drag DOES trigger the end callback',
+        (tester) async {
+      var endCount = 0;
+      await _pumpWithSingleTouchRecognizer(
+        tester,
+        onHorizontalDragEnd: (_) => endCount++,
+      );
+
+      await tester.drag(
+        find.byKey(_testKey),
+        const Offset(200, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(endCount, 1,
+          reason: 'single-finger drag should fire the end callback');
+    });
+
+    testWidgets(
+        'two-finger drag does NOT trigger the end callback (this is the '
+        'whole point of the subclass)', (tester) async {
+      var endCount = 0;
+      await _pumpWithSingleTouchRecognizer(
+        tester,
+        onHorizontalDragEnd: (_) => endCount++,
+      );
+
+      // Manually simulate two fingers landing then dragging horizontally.
+      const center = Offset(_viewportWidth / 2, _viewportHeight / 2);
+      final g1 =
+          await tester.startGesture(center + const Offset(-30, 0));
+      final g2 =
+          await tester.startGesture(center + const Offset(30, 0));
+      // Move them apart horizontally over several frames.
+      for (var i = 0; i < 10; i++) {
+        await g1.moveBy(const Offset(-10, 0));
+        await g2.moveBy(const Offset(10, 0));
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      await g1.up();
+      await g2.up();
+      await tester.pumpAndSettle();
+
+      expect(endCount, 0,
+          reason: 'two-finger gesture must NOT be claimed by the '
+              'single-touch drag recognizer — that lets ZoomView win.');
+    });
+
+    testWidgets(
+        'after a multi-touch gesture, a fresh single-finger drag still works',
+        (tester) async {
+      var endCount = 0;
+      await _pumpWithSingleTouchRecognizer(
+        tester,
+        onHorizontalDragEnd: (_) => endCount++,
+      );
+
+      // First: a two-finger gesture that should be ignored.
+      const center = Offset(_viewportWidth / 2, _viewportHeight / 2);
+      final g1 =
+          await tester.startGesture(center + const Offset(-30, 0));
+      final g2 =
+          await tester.startGesture(center + const Offset(30, 0));
+      for (var i = 0; i < 5; i++) {
+        await g1.moveBy(const Offset(-10, 0));
+        await g2.moveBy(const Offset(10, 0));
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      await g1.up();
+      await g2.up();
+      await tester.pumpAndSettle();
+
+      expect(endCount, 0, reason: 'multi-touch should not have fired');
+
+      // Now: a single-finger drag should still work.
+      await tester.drag(
+        find.byKey(_testKey),
+        const Offset(200, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(endCount, 1,
+          reason: 'a fresh single-finger drag must still fire — the '
+              'recognizer must not be left in a broken state');
+    });
+  });
+}

--- a/test/src/widgets/zoom/zoom_view_wiring_test.dart
+++ b/test/src/widgets/zoom/zoom_view_wiring_test.dart
@@ -1,0 +1,247 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Tests for the pinch-to-zoom wiring used by the reader modes.
+//
+// Background: ZoomView is wrapped around a ScrollablePositionedList (or a
+// PageView in the single-page case) and is supposed to capture two-finger
+// scale gestures. Without `forceHoldOnPointerDown: true`, the underlying
+// scrollable's pan recognizer wins the gesture arena and `ZoomView` never
+// sees the scale start — pinch does literally nothing on device. These
+// tests pin both behaviours: the scale callback fires when forceHold is
+// on, and the single-finger scroll path still works regardless.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:tachidesk_sorayomi/src/widgets/zoom/scroll_offset_to_scroll_controller.dart';
+import 'package:zoom_view/zoom_view.dart';
+
+const double _viewportWidth = 400.0;
+const double _viewportHeight = 800.0;
+const double _itemHeight = 200.0;
+
+Future<void> _pumpZoomWrappedList(
+  WidgetTester tester, {
+  required bool forceHoldOnPointerDown,
+  required void Function(double scale) onScaleChanged,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(_viewportWidth, _viewportHeight);
+  addTearDown(() {
+    tester.view.resetDevicePixelRatio();
+    tester.view.resetPhysicalSize();
+  });
+
+  final scrollOffsetController = ScrollOffsetController();
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: _viewportWidth,
+          height: _viewportHeight,
+          child: ZoomView(
+            controller: ScrollOffsetToScrollController(
+              scrollOffsetController: scrollOffsetController,
+            ),
+            scrollAxis: Axis.vertical,
+            maxScale: 5,
+            forceHoldOnPointerDown: forceHoldOnPointerDown,
+            onScaleChanged: onScaleChanged,
+            child: ScrollablePositionedList.builder(
+              scrollOffsetController: scrollOffsetController,
+              itemCount: 50,
+              itemBuilder: (context, index) => SizedBox(
+                height: _itemHeight,
+                child: Text('Item $index'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  // Let the list mount and attach controllers.
+  await tester.pumpAndSettle();
+}
+
+/// Drive a two-finger pinch-out gesture (two pointers moving apart).
+Future<void> _simulatePinchOut(WidgetTester tester) async {
+  final center = const Offset(_viewportWidth / 2, _viewportHeight / 2);
+  // Start two fingers near the center, ~60px apart, then pull them apart
+  // along the diagonal so the scale delta is significant.
+  final start1 = center + const Offset(-30, -30);
+  final start2 = center + const Offset(30, 30);
+  final g1 = await tester.startGesture(start1);
+  final g2 = await tester.startGesture(start2);
+  // Pull them apart over several frames to give the scale recognizer time
+  // to accept past its slop threshold.
+  for (var i = 0; i < 10; i++) {
+    await g1.moveBy(const Offset(-10, -10));
+    await g2.moveBy(const Offset(10, 10));
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+  await g1.up();
+  await g2.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ZoomView + ScrollablePositionedList pinch wiring', () {
+    testWidgets(
+        'WITH forceHoldOnPointerDown=true (our fix): pinch fires the scale '
+        'callback with scale > 1.0', (tester) async {
+      double? lastScale;
+      await _pumpZoomWrappedList(
+        tester,
+        forceHoldOnPointerDown: true,
+        onScaleChanged: (scale) => lastScale = scale,
+      );
+
+      await _simulatePinchOut(tester);
+
+      expect(lastScale, isNotNull,
+          reason: 'onScaleChanged should fire when forceHoldOnPointerDown '
+              'is set — that is the whole point of the flag for SPL');
+      expect(lastScale!, greaterThan(1.0),
+          reason: 'pinch-out should produce a scale > 1.0');
+    });
+
+    testWidgets(
+        'single-finger drag still scrolls the underlying list through the '
+        'ZoomView wrapper (does not block normal scrolling)', (tester) async {
+      await _pumpZoomWrappedList(
+        tester,
+        forceHoldOnPointerDown: true,
+        onScaleChanged: (_) {},
+      );
+
+      // Item 0 should be at the top of the viewport initially.
+      expect(tester.getTopLeft(find.text('Item 0')).dy, closeTo(0.0, 0.5),
+          reason: 'sanity: list starts at the top');
+
+      // One-finger drag upward through the ZoomView wrapper.
+      await tester.drag(
+        find.byType(ScrollablePositionedList),
+        const Offset(0, -400),
+      );
+      await tester.pumpAndSettle();
+
+      // Item 0 should have scrolled out of view (above the viewport).
+      final item0Finder = find.text('Item 0');
+      if (item0Finder.evaluate().isNotEmpty) {
+        final item0Y = tester.getTopLeft(item0Finder).dy;
+        expect(item0Y, lessThan(-50.0),
+            reason: 'after a single-finger drag, Item 0 should have moved '
+                'off the top of the viewport — ZoomView must not block '
+                'normal scrolling');
+      }
+      // If Item 0 isn't found at all, that's also evidence the list scrolled.
+    });
+  });
+
+  group('reproducing the reader\'s real gesture stack', () {
+    testWidgets(
+        'GestureDetector(onPanEnd + onLongPress + onTap) wrapping ZoomView: '
+        'does the outer pan recognizer eat the pinch?', (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(_viewportWidth, _viewportHeight);
+      addTearDown(() {
+        tester.view.resetDevicePixelRatio();
+        tester.view.resetPhysicalSize();
+      });
+
+      double? lastScale;
+      var outerPanEnds = 0;
+      final scrollOffsetController = ScrollOffsetController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: _viewportWidth,
+              height: _viewportHeight,
+              // This mimics the structure inside ReaderWrapper:
+              // DirectionalSwipeGestureHandler wraps everything in a
+              // GestureDetector with onPanEnd, onTap, onLongPress*. That
+              // GestureDetector sits ABOVE ZoomView in the widget tree.
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: () {},
+                onLongPressStart: (_) {},
+                onLongPressEnd: (_) {},
+                onLongPressMoveUpdate: (_) {},
+                onPanEnd: (_) => outerPanEnds++,
+                child: ZoomView(
+                  controller: ScrollOffsetToScrollController(
+                    scrollOffsetController: scrollOffsetController,
+                  ),
+                  scrollAxis: Axis.vertical,
+                  maxScale: 5,
+                  forceHoldOnPointerDown: true,
+                  onScaleChanged: (s) => lastScale = s,
+                  child: ScrollablePositionedList.builder(
+                    scrollOffsetController: scrollOffsetController,
+                    itemCount: 50,
+                    itemBuilder: (context, index) => SizedBox(
+                      height: _itemHeight,
+                      child: Text('Item $index'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await _simulatePinchOut(tester);
+
+      printOnFailure('lastScale: $lastScale');
+      printOnFailure('outerPanEnds: $outerPanEnds');
+
+      // If the outer GestureDetector eats the pinch (the device-side
+      // hypothesis), lastScale stays null and outerPanEnds increments.
+      // If ZoomView still wins, lastScale is non-null.
+      if (lastScale == null && outerPanEnds > 0) {
+        fail(
+          'OUTER GESTURE DETECTOR ATE THE PINCH (reproduced in test env). '
+          'lastScale=$lastScale, outerPanEnds=$outerPanEnds. This is '
+          'the device-side bug.',
+        );
+      } else if (lastScale == null) {
+        fail(
+          'pinch did not fire scale but the outer GestureDetector also '
+          'did not see a pan-end. Some other recognizer is eating the '
+          'gesture. lastScale=$lastScale, outerPanEnds=$outerPanEnds.',
+        );
+      }
+      // If we reach here, scale fired despite the outer wrapper — the
+      // outer-GD-eats-pinch hypothesis is wrong (in test env at least).
+      expect(lastScale, greaterThan(1.0));
+    });
+  });
+
+  group('limitations of these tests (read this before relying on them)', () {
+    test(
+        'widget-test gesture arena does NOT reproduce real-device multi-touch '
+        'arena losses', () {
+      // Documented in code, not asserted: in the Flutter widget-test
+      // environment the scale recognizer wins the arena over the underlying
+      // scrollable\'s pan recognizer EVEN WITHOUT `forceHoldOnPointerDown`.
+      // On a real Android device the scrollable wins and the scale gesture
+      // never starts. That is the entire bug `forceHoldOnPointerDown: true`
+      // exists to work around. Therefore a passing pinch test here does
+      // NOT prove the fix works on hardware; the hardware verification is
+      // a separate step.
+      //
+      // This test exists only to keep the limitation explicit in the file.
+      expect(true, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #256.

## The bug

Reported in #256: two-finger pinch is "almost unusable" on Android — you have to "find the right angle" before it triggers. In practice it works once in ten attempts, never reliably.

## Root cause

Gesture-arena race. The reader wraps content in `DirectionalSwipeGestureHandler`, whose `HorizontalDragGestureRecognizer` / `VerticalDragGestureRecognizer` accept the gesture as soon as either finger drifts past drag-slop (~18px). Meanwhile `InteractiveViewer`'s scale recognizer is waiting for an actual scale delta to claim. The drag recognizer almost always wins, eating the pinch. Fast pinches occasionally race through because the scale delta accumulates faster.

Verified on a Pixel 9 Pro with an in-app diagnostic counter overlay (since stripped): scale callbacks fired zero times during slow pinches, while the outer drag recognizer's end fired every time.

## The fix

Two pieces:

1. **Replace `InteractiveViewer` with [`zoom_view`](https://pub.dev/packages/zoom_view).** Suggested by @DattatreyaReddy in [the issue thread itself](https://github.com/Suwayomi/Tachidesk-Sorayomi/issues/256#issuecomment-2547904958). It's a Flutter package designed for the "zoom inside a scrollable" case — handles gesture-arena coordination between scale and scroll via a shared controller.

2. **Small `HorizontalDragGestureRecognizer` / `VerticalDragGestureRecognizer` subclasses in `DirectionalSwipeGestureHandler` that reject multi-touch.** When a second finger lands, the recognizer rejects its in-flight gesture via `resolve(GestureDisposition.rejected)` so the scale recognizer can claim. Single-finger swipes (the swipe-at-chapter-boundary feature) are unchanged. Tap and long-press handlers stay on a nested standard `GestureDetector` since they don't compete with multi-touch.

Configured `zoom_view`'s `forceHoldOnPointerDown: true` flag (recommended by the package for use inside `ScrollablePositionedList`) and `doubleTapDrag: true` for the standard double-tap-to-zoom affordance.

## Dependency situation (please read)

`ScrollablePositionedList` doesn't expose a standard `ScrollController` — `zoom_view` needs one to coordinate scroll position with zoom. There's an open upstream PR at [google/flutter.widgets#535](https://github.com/google/flutter.widgets/pull/535) (by `yakagami`, the same author as `zoom_view`) that adds the needed `ScrollPosition` getter on `ScrollOffsetController` — 2-line change. It's been open since June 2024.

Pending that merge, this PR pins `scrollable_positioned_list` to yakagami's fork via git URL in `pubspec.yaml`. There's a comment in pubspec linking to PR #535 noting the situation; once Google's PR lands, the line can be reverted to a `pub.dev` version.

If you'd rather not introduce a git dep, the alternative is to vendor the 2-line change into a local copy of the package. Happy to take that path instead — just say the word.

## Tests

Three widget tests under `test/src/widgets/zoom/` cover the recognizer behavior:

- Single-finger drag still triggers the end callback (didn't break the swipe-at-boundary feature).
- Two-finger drag does NOT trigger the end callback (the actual fix).
- After a multi-touch gesture, a fresh single-finger drag still works (the recognizer isn't left in a broken state).

One important note: the widget-test gesture arena is more permissive than the real-device arena. The test fixture deliberately includes a no-op `ScaleGestureRecognizer` so the arena has competition — without it, the lone drag recognizer eager-accepts and masks the bug. There's a documentation-only test calling this limitation out explicitly.
