### PR TITLE
Add Suwayomi native authentication (simple_login + ui_login)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,10 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'src/features/about/presentation/about/controllers/about_controller.dart';
+import 'src/features/auth/data/auth_credentials_store.dart';
+import 'src/features/auth/data/basic_auth_migration.dart';
+import 'src/features/auth/data/secure_credentials_provider.dart';
+import 'src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
 import 'src/global_providers/global_providers.dart';
 import 'src/sorayomi.dart';
 
@@ -24,13 +28,45 @@ Future<void> main() async {
 
   SystemChrome.setPreferredOrientations(DeviceOrientation.values);
   GoRouter.optionURLReflectsImperativeAPIs = true;
+
+  // Build a ProviderContainer so we can run migration and preload auth
+  // providers before the first frame. Using UncontrolledProviderScope below
+  // ensures the widget tree uses this same container instance.
+  final container = ProviderContainer(
+    overrides: [
+      packageInfoProvider.overrideWithValue(packageInfo),
+      sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+      hiveStoreProvider.overrideWithValue(HiveStore()),
+    ],
+  );
+
+  final secure = container.read(secureStorageProvider);
+
+  // 1) Migrate legacy SharedPreferences basic-auth → secure storage.
+  try {
+    await migrateBasicAuthCredentials(prefs: sharedPreferences, secure: secure);
+  } catch (e, st) {
+    debugPrint('basic_auth migration failed: $e\n$st');
+    // Non-fatal: legacy creds stay in SharedPreferences for one more launch.
+  }
+
+  // 2) Preload both auth providers BEFORE the first frame so synchronous reads
+  //    (image widgets, GraphQL links) get populated state instead of
+  //    AsyncLoading — which would produce tokenless requests that get cached
+  //    as 401 failures by cached_network_image.
+  try {
+    await Future.wait([
+      container.read(authCredentialsStoreProvider.future),
+      container.read(credentialsProvider.future),
+    ]);
+  } catch (e, st) {
+    debugPrint('auth preload failed, falling back to empty state: $e\n$st');
+    // Both notifiers will re-attempt on first widget read. App still launches.
+  }
+
   runApp(
-    ProviderScope(
-      overrides: [
-        packageInfoProvider.overrideWithValue(packageInfo),
-        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
-        hiveStoreProvider.overrideWithValue(HiveStore())
-      ],
+    UncontrolledProviderScope(
+      container: container,
       child: const Sorayomi(),
     ),
   );

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -20,6 +20,7 @@ enum DBKeys {
   isTrueBlack(false),
   authType(AuthType.none),
   basicCredentials(null),
+  authUsername(null),
   readerMode(ReaderMode.webtoon),
   readerPadding(0.0),
   readerMagnifierSize(1.0),

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -12,11 +12,15 @@ import '../utils/extensions/custom_extensions.dart';
 
 enum AuthType {
   none,
-  basic;
+  basic,
+  simpleLogin,
+  uiLogin;
 
   String toLocale(BuildContext context) => switch (this) {
         AuthType.none => context.l10n.authTypeNone,
         AuthType.basic => context.l10n.authTypeBasic,
+        AuthType.simpleLogin => context.l10n.authTypeSimpleLogin,
+        AuthType.uiLogin => context.l10n.authTypeUiLogin,
       };
 }
 

--- a/lib/src/constants/gen/assets.gen.dart
+++ b/lib/src/constants/gen/assets.gen.dart
@@ -55,12 +55,12 @@ class $AssetsIconsLauncherGen {
 
   /// List of all assets
   List<dynamic> get values => [
-        fromSuwayomi,
-        iosSorayomiIcon,
-        sorayomiIconIco,
-        sorayomiIconPng,
-        sorayomiPreviewIcon,
-      ];
+    fromSuwayomi,
+    iosSorayomiIcon,
+    sorayomiIconIco,
+    sorayomiIconPng,
+    sorayomiPreviewIcon,
+  ];
 }
 
 class Assets {

--- a/lib/src/features/auth/data/auth_coordinator.dart
+++ b/lib/src/features/auth/data/auth_coordinator.dart
@@ -1,0 +1,380 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async'; // Completer — required by single-flight refresh
+
+import 'package:flutter/foundation.dart'; // debugPrint
+import 'package:graphql/client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/enum.dart';
+// Input types are defined in the schema file and NOT re-exported by
+// auth.graphql.dart, so we import the schema directly.
+import '../../../graphql/__generated__/schema.graphql.dart'
+    show Input$LoginInput, Input$RefreshTokenInput;
+import 'auth_credentials_store.dart';
+import 'auth_state.dart';
+import 'graphql/__generated__/auth.graphql.dart';
+import 'simple_login_client.dart';
+
+part 'auth_coordinator.g.dart';
+
+/// Result of a Test Connection attempt.
+sealed class TestConnectionResult {
+  const TestConnectionResult();
+}
+
+class TestConnectionSuccess extends TestConnectionResult {
+  const TestConnectionSuccess();
+}
+
+class TestConnectionFailure extends TestConnectionResult {
+  const TestConnectionFailure(this.kind, [this.detail]);
+  final TestConnectionFailureKind kind;
+  final String? detail;
+}
+
+enum TestConnectionFailureKind {
+  network,
+  invalidCredentials,
+  wrongAuthMode,
+  unexpectedShape,
+  insecureTransport,
+}
+
+/// Outcome of a refresh attempt. Top-level sealed type — DECLARED HERE
+/// (above [AuthCoordinator]) so the class body that references it can
+/// stay contiguous. This placement matters: in round 2 the sealed
+/// classes were inserted MID-CLASS by accident, which forced
+/// `testConnection` to fall outside the class and broke compilation.
+sealed class RefreshOutcome {
+  const RefreshOutcome();
+  const factory RefreshOutcome.success(String newAccessToken) =
+      RefreshSuccess;
+  const factory RefreshOutcome.authFailure() = RefreshAuthFailure;
+  const factory RefreshOutcome.transientFailure(Object error) =
+      RefreshTransientFailure;
+}
+
+class RefreshSuccess extends RefreshOutcome {
+  const RefreshSuccess(this.newAccessToken);
+  final String newAccessToken;
+}
+
+class RefreshAuthFailure extends RefreshOutcome {
+  const RefreshAuthFailure();
+}
+
+class RefreshTransientFailure extends RefreshOutcome {
+  const RefreshTransientFailure(this.error);
+  final Object error;
+}
+
+/// Process-wide single-flight slot for UI Login refresh.
+///
+/// Held as a TOP-LEVEL static — not a notifier field — so it survives
+/// provider invalidation (Codex round-3 finding: if a Riverpod
+/// invalidate recreates [AuthCoordinator] mid-refresh, an instance
+/// field would silently allow a second concurrent refresh). The
+/// trade-off: tests that exercise the static must reset it via
+/// `debugResetAuthCoordinatorSingleFlight()` in `setUp`.
+Completer<RefreshOutcome>? _refreshInFlight;
+
+/// Test hook to clear the file-static single-flight slot between tests.
+@visibleForTesting
+void debugResetAuthCoordinatorSingleFlight() {
+  _refreshInFlight = null;
+}
+
+/// Extracts an HTTP status code from a graphql_flutter [LinkException],
+/// or `null` if the exception isn't an HTTP-layer one. Used by
+/// [AuthCoordinator._refreshUiAccessTokenImpl] to tell auth failures
+/// (401/403) from transient failures (sockets, 5xx, timeout). Defined
+/// at file scope so tests can drive it without standing up an
+/// AuthCoordinator. — Codex round-3 finding.
+int? _httpStatusOfLinkException(LinkException ex) {
+  if (ex is HttpLinkServerException) {
+    return ex.response.statusCode;
+  }
+  // ResponseFormatException / ServerException / NetworkException etc.
+  // don't carry a status code — treat as transient.
+  return null;
+}
+
+/// Orchestrates login, re-auth, and test-connection flows for the two new
+/// auth modes. Pure logic — the UI calls into this and observes the
+/// resulting state via [AuthCredentialsStore] and [NeedsReauth].
+@Riverpod(keepAlive: true)
+class AuthCoordinator extends _$AuthCoordinator {
+  @override
+  void build() {}
+
+  // ---------- Verify-only paths (no persistence) ----------
+  //
+  // These run the same network round-trips as the real login flows but
+  // do NOT touch secure storage. Used by the credentials popup's Test
+  // Connection button so a user can verify without committing anything
+  // — clicking Cancel must leave the existing config untouched.
+  //
+  // **Caveat for simple_login (R2-11):** `verifySimpleCredentials` calls
+  // `POST /login.html`, which creates a server-side session and returns a
+  // cookie. Discarding the cookie does NOT delete the session — Suwayomi
+  // will accumulate orphan sessions if the user hammers Test. The
+  // existing simple_login docs don't expose a logout-without-cookie
+  // endpoint, so we accept this as a documented limitation. UX guidance:
+  // the popup should treat Test as "soft commit" — successive Tests
+  // overwrite each other server-side, and Save reuses the most recent
+  // verified cookie (see Task 17) so a typical Test → Save sequence
+  // produces exactly one session.
+
+  /// Verifies Simple Login credentials by POSTing to /login.html. Returns
+  /// the session cookie on success; throws on failure. Caller decides
+  /// whether to persist (via [loginSimple]) or discard.
+  Future<String> verifySimpleCredentials({
+    required String serverBaseUrl,
+    required String username,
+    required String password,
+  }) async {
+    final client = SimpleLoginClient();
+    return await client.login(
+      serverBaseUrl: serverBaseUrl,
+      username: username,
+      password: password,
+    );
+  }
+
+  /// Verifies UI Login credentials by firing the `login` mutation.
+  /// Returns the token pair on success; throws on failure. Caller
+  /// decides whether to persist (via [loginUi]) or discard.
+  Future<UiLoginTokens> verifyUiCredentials({
+    required GraphQLClient gqlClient,
+    required String username,
+    required String password,
+  }) async {
+    final result = await gqlClient.mutate$Login(Options$Mutation$Login(
+      variables: Variables$Mutation$Login(
+        input: Input$LoginInput(
+          username: username,
+          password: password,
+        ),
+      ),
+    ));
+    if (result.hasException) {
+      throw result.exception!;
+    }
+    final payload = result.parsedData?.login;
+    if (payload == null) {
+      throw Exception('login mutation returned null payload');
+    }
+    return UiLoginTokens(
+      accessToken: payload.accessToken,
+      refreshToken: payload.refreshToken,
+    );
+  }
+
+  // ---------- Persisting login paths ----------
+
+  /// Performs Simple Login AND persists the resulting cookie + password.
+  /// Equivalent to `verifySimpleCredentials` + a store write. Used by
+  /// the credentials popup's Save button.
+  Future<void> loginSimple({
+    required String serverBaseUrl,
+    required String username,
+    required String password,
+  }) async {
+    final cookie = await verifySimpleCredentials(
+      serverBaseUrl: serverBaseUrl,
+      username: username,
+      password: password,
+    );
+    final store = ref.read(authCredentialsStoreProvider.notifier);
+    await store.saveSimpleLoginCookie(cookie);
+    await store.savePassword(password);
+    ref.read(needsReauthProvider.notifier).set(false);
+  }
+
+  /// Performs UI Login AND persists both tokens + password.
+  Future<void> loginUi({
+    required GraphQLClient gqlClient,
+    required String username,
+    required String password,
+  }) async {
+    final tokens = await verifyUiCredentials(
+      gqlClient: gqlClient,
+      username: username,
+      password: password,
+    );
+    final store = ref.read(authCredentialsStoreProvider.notifier);
+    await store.saveUiLoginTokens(
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    );
+    await store.savePassword(password);
+    ref.read(needsReauthProvider.notifier).set(false);
+  }
+
+  /// Calls the `refreshToken` mutation. Returns a typed [RefreshOutcome].
+  /// Process-wide single-flight is handled via the FILE-STATIC
+  /// `_refreshInFlight` Completer declared above this class (Codex
+  /// round-3 finding: instance-field placement breaks if the notifier
+  /// is invalidated mid-refresh).
+  ///
+  /// On `success`: updates the store's access token.
+  /// On `authFailure`: clears tokens and sets `needsReauth = true`.
+  /// On `transientFailure`: leaves state untouched; caller logs/retries.
+  ///
+  /// Concurrent callers share one in-flight refresh.
+  Future<RefreshOutcome> refreshUiAccessToken({
+    required GraphQLClient gqlClient,
+  }) async {
+    final inFlight = _refreshInFlight;
+    if (inFlight != null) return inFlight.future;
+
+    final completer = Completer<RefreshOutcome>();
+    _refreshInFlight = completer;
+    try {
+      final outcome = await _refreshUiAccessTokenImpl(gqlClient);
+      completer.complete(outcome);
+      return outcome;
+    } catch (e, st) {
+      // _refreshUiAccessTokenImpl handles its own errors; this catch is
+      // strictly defensive. A throw here is a programmer error, not an
+      // auth/network failure — surface it transient so we don't wipe
+      // tokens for the wrong reason.
+      debugPrint('refreshUiAccessToken: unexpected throw: $e\n$st');
+      final outcome = RefreshOutcome.transientFailure(e);
+      completer.complete(outcome);
+      return outcome;
+    } finally {
+      _refreshInFlight = null;
+    }
+  }
+
+  Future<RefreshOutcome> _refreshUiAccessTokenImpl(
+      GraphQLClient gqlClient) async {
+    final store = ref.read(authCredentialsStoreProvider.notifier);
+    final tokens = store.uiLoginTokens();
+    if (tokens == null) {
+      // No tokens to refresh = nothing more we can do. This is treated
+      // as auth failure (the user must log in again) rather than
+      // transient — there's no path forward without re-auth.
+      ref.read(needsReauthProvider.notifier).set(true);
+      return const RefreshOutcome.authFailure();
+    }
+
+    final QueryResult<Mutation$RefreshToken> result;
+    try {
+      result = await gqlClient.mutate$RefreshToken(
+        Options$Mutation$RefreshToken(
+          variables: Variables$Mutation$RefreshToken(
+            input: Input$RefreshTokenInput(refreshToken: tokens.refreshToken),
+          ),
+        ),
+      );
+    } catch (e, st) {
+      // Network/socket/timeout — DON'T clear tokens. The refresh token
+      // may still be perfectly good; we just couldn't reach the server.
+      debugPrint('refreshToken network error: $e\n$st');
+      return RefreshOutcome.transientFailure(e);
+    }
+
+    final exception = result.exception;
+    if (exception != null) {
+      // Distinguish network-style GraphQL errors (linkException) from
+      // server-rejected auth errors (graphqlErrors with 401-ish status).
+      //
+      // Codex round-3 finding: not every linkException is transient.
+      // Suwayomi's refresh-token rejection can arrive as
+      // `HttpLinkServerException` with HTTP 401/403 — that's an AUTH
+      // failure, not a network blip. We need to inspect the inner
+      // exception's status code before classifying.
+      final link = exception.linkException;
+      if (link != null) {
+        final status = _httpStatusOfLinkException(link);
+        if (status == 401 || status == 403) {
+          // Server actively rejected the refresh token at the HTTP
+          // layer. Treat as auth failure.
+          await store.clearUiLoginTokens();
+          ref.read(needsReauthProvider.notifier).set(true);
+          return const RefreshOutcome.authFailure();
+        }
+        // Other link exceptions (socket, timeout, server 5xx) are
+        // transient — keep tokens, let the user retry.
+        return RefreshOutcome.transientFailure(exception);
+      }
+      // GraphQL errors (non-link) here mean the server actively
+      // rejected the refresh token at the GraphQL layer — clear and
+      // prompt re-auth.
+      await store.clearUiLoginTokens();
+      ref.read(needsReauthProvider.notifier).set(true);
+      return const RefreshOutcome.authFailure();
+    }
+
+    final newAccess = result.parsedData?.refreshToken.accessToken;
+    if (newAccess == null) {
+      // No exception, but no token either — treat as auth failure.
+      await store.clearUiLoginTokens();
+      ref.read(needsReauthProvider.notifier).set(true);
+      return const RefreshOutcome.authFailure();
+    }
+    await store.updateUiLoginAccessToken(newAccess);
+    return RefreshOutcome.success(newAccess);
+  }
+
+  /// Runs the appropriate verify-only round-trip and returns a typed
+  /// [TestConnectionResult]. **Does not persist credentials** — caller
+  /// must call [loginSimple] / [loginUi] explicitly to commit. This way
+  /// hitting Test → Cancel leaves prior config untouched.
+  Future<TestConnectionResult> testConnection({
+    required AuthType authType,
+    required String serverBaseUrl,
+    required String username,
+    required String password,
+    required GraphQLClient Function() makeGqlClient,
+  }) async {
+    try {
+      if (authType == AuthType.simpleLogin) {
+        await verifySimpleCredentials(
+          serverBaseUrl: serverBaseUrl,
+          username: username,
+          password: password,
+        );
+      } else if (authType == AuthType.uiLogin) {
+        await verifyUiCredentials(
+          gqlClient: makeGqlClient(),
+          username: username,
+          password: password,
+        );
+      } else {
+        return const TestConnectionFailure(
+            TestConnectionFailureKind.unexpectedShape,
+            'testConnection only supports simpleLogin or uiLogin');
+      }
+    } on SimpleLoginAuthFailure {
+      return const TestConnectionFailure(
+          TestConnectionFailureKind.invalidCredentials);
+    } on SimpleLoginShapeFailure catch (e) {
+      return TestConnectionFailure(
+          TestConnectionFailureKind.unexpectedShape, e.message);
+    } catch (e) {
+      final msg = e.toString().toLowerCase();
+      if (msg.contains('unauthor') || msg.contains('forbidden')) {
+        return const TestConnectionFailure(
+            TestConnectionFailureKind.invalidCredentials);
+      }
+      if (msg.contains('socket') ||
+          msg.contains('timeout') ||
+          msg.contains('host') ||
+          msg.contains('connection')) {
+        return const TestConnectionFailure(
+            TestConnectionFailureKind.network);
+      }
+      return TestConnectionFailure(
+          TestConnectionFailureKind.unexpectedShape, e.toString());
+    }
+    return const TestConnectionSuccess();
+  }
+}

--- a/lib/src/features/auth/data/auth_coordinator.dart
+++ b/lib/src/features/auth/data/auth_coordinator.dart
@@ -39,10 +39,50 @@ class TestConnectionFailure extends TestConnectionResult {
 
 enum TestConnectionFailureKind {
   network,
+  tls,
   invalidCredentials,
   wrongAuthMode,
   unexpectedShape,
   insecureTransport,
+}
+
+/// Maps a thrown error to a typed [TestConnectionFailure]. Used by both
+/// `testConnection` and the credentials popup's Save path so both surface
+/// the same friendly message instead of a raw exception toString().
+///
+/// TLS errors (`HandshakeException: Wrong version number`) are checked
+/// BEFORE network errors because their toString() also contains tokens
+/// like "connection" that would otherwise collapse them into a generic
+/// network failure.
+TestConnectionFailure classifyAuthError(Object e) {
+  if (e is SimpleLoginAuthFailure) {
+    return const TestConnectionFailure(
+        TestConnectionFailureKind.invalidCredentials);
+  }
+  if (e is SimpleLoginShapeFailure) {
+    return TestConnectionFailure(
+        TestConnectionFailureKind.unexpectedShape, e.message);
+  }
+  final msg = e.toString().toLowerCase();
+  if (msg.contains('unauthor') || msg.contains('forbidden')) {
+    return const TestConnectionFailure(
+        TestConnectionFailureKind.invalidCredentials);
+  }
+  if (msg.contains('handshake') ||
+      msg.contains('wrong version') ||
+      msg.contains('certificate') ||
+      msg.contains('tls') ||
+      msg.contains(' ssl')) {
+    return const TestConnectionFailure(TestConnectionFailureKind.tls);
+  }
+  if (msg.contains('socket') ||
+      msg.contains('timeout') ||
+      msg.contains('host') ||
+      msg.contains('connection')) {
+    return const TestConnectionFailure(TestConnectionFailureKind.network);
+  }
+  return TestConnectionFailure(
+      TestConnectionFailureKind.unexpectedShape, e.toString());
 }
 
 /// Outcome of a refresh attempt. Top-level sealed type — DECLARED HERE
@@ -353,27 +393,8 @@ class AuthCoordinator extends _$AuthCoordinator {
             TestConnectionFailureKind.unexpectedShape,
             'testConnection only supports simpleLogin or uiLogin');
       }
-    } on SimpleLoginAuthFailure {
-      return const TestConnectionFailure(
-          TestConnectionFailureKind.invalidCredentials);
-    } on SimpleLoginShapeFailure catch (e) {
-      return TestConnectionFailure(
-          TestConnectionFailureKind.unexpectedShape, e.message);
     } catch (e) {
-      final msg = e.toString().toLowerCase();
-      if (msg.contains('unauthor') || msg.contains('forbidden')) {
-        return const TestConnectionFailure(
-            TestConnectionFailureKind.invalidCredentials);
-      }
-      if (msg.contains('socket') ||
-          msg.contains('timeout') ||
-          msg.contains('host') ||
-          msg.contains('connection')) {
-        return const TestConnectionFailure(
-            TestConnectionFailureKind.network);
-      }
-      return TestConnectionFailure(
-          TestConnectionFailureKind.unexpectedShape, e.toString());
+      return classifyAuthError(e);
     }
     return const TestConnectionSuccess();
   }

--- a/lib/src/features/auth/data/auth_credentials_store.dart
+++ b/lib/src/features/auth/data/auth_credentials_store.dart
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'secure_credentials_provider.dart';
+
+part 'auth_credentials_store.g.dart';
+
+/// Holds an access + refresh token pair for UI Login mode.
+class UiLoginTokens {
+  const UiLoginTokens({required this.accessToken, required this.refreshToken});
+  final String accessToken;
+  final String refreshToken;
+}
+
+/// In-memory snapshot of every credential the app holds. This is the
+/// `state` of [AuthCredentialsStore] — synchronously readable via
+/// `ref.watch(authCredentialsStoreProvider).valueOrNull` so widgets like
+/// `server_image` can authenticate on the first frame without an
+/// `AsyncLoading` flash that would otherwise cache a 401.
+///
+/// All fields are nullable: any value the user hasn't set is simply `null`.
+class AuthCredentialsState {
+  const AuthCredentialsState({
+    this.password,
+    this.simpleLoginCookie,
+    this.uiAccessToken,
+    this.uiRefreshToken,
+  });
+
+  const AuthCredentialsState.empty()
+      : password = null,
+        simpleLoginCookie = null,
+        uiAccessToken = null,
+        uiRefreshToken = null;
+
+  final String? password;
+  final String? simpleLoginCookie;
+  final String? uiAccessToken;
+  final String? uiRefreshToken;
+
+  /// Convenience: `{'Authorization': 'Bearer <jwt>'}` or `null` when no
+  /// access token is present. Used by `SuwayomiAuthLink.getHeaders`.
+  Map<String, String>? get uiAuthorizationHeader =>
+      (uiAccessToken == null || uiAccessToken!.isEmpty)
+          ? null
+          : {'Authorization': 'Bearer $uiAccessToken'};
+
+  /// Convenience: `{'Cookie': '<cookie>'}` or `null`. Used by
+  /// `SuwayomiAuthLink.getHeaders` and `server_image`.
+  Map<String, String>? get simpleLoginCookieHeader =>
+      (simpleLoginCookie == null || simpleLoginCookie!.isEmpty)
+          ? null
+          : {'Cookie': simpleLoginCookie!};
+
+  AuthCredentialsState copyWith({
+    String? password,
+    bool clearPassword = false,
+    String? simpleLoginCookie,
+    bool clearSimpleLoginCookie = false,
+    String? uiAccessToken,
+    bool clearUiAccessToken = false,
+    String? uiRefreshToken,
+    bool clearUiRefreshToken = false,
+  }) {
+    return AuthCredentialsState(
+      password: clearPassword ? null : (password ?? this.password),
+      simpleLoginCookie: clearSimpleLoginCookie
+          ? null
+          : (simpleLoginCookie ?? this.simpleLoginCookie),
+      uiAccessToken: clearUiAccessToken
+          ? null
+          : (uiAccessToken ?? this.uiAccessToken),
+      uiRefreshToken: clearUiRefreshToken
+          ? null
+          : (uiRefreshToken ?? this.uiRefreshToken),
+    );
+  }
+}
+
+/// Typed wrapper over `flutter_secure_storage` for auth credentials.
+///
+/// Storage key conventions (all in secure storage):
+///   `auth.password`            — password for simpleLogin + uiLogin re-auth
+///   `auth.simple.cookie`       — full Cookie header value (e.g.
+///                                "JSESSIONID=abc123") for simpleLogin
+///   `auth.ui.accessToken`      — current uiLogin access token (JWT)
+///   `auth.ui.refreshToken`     — uiLogin refresh token (JWT)
+///   `auth.basic.credentials`   — migrated `Basic <base64(user:pass)>` from
+///                                legacy SharedPreferences (see Task 7a)
+///
+/// Username lives in SharedPreferences (via DBKeys.authUsername) since it's
+/// not sensitive on its own.
+///
+/// **Reactivity:** This is an `AsyncNotifier`. `build()` loads every key from
+/// secure storage exactly once at startup; mutators write through to
+/// secure storage AND update `state`, so widgets watching the provider
+/// rebuild immediately on token rotation / login / logout.
+@Riverpod(keepAlive: true)
+class AuthCredentialsStore extends _$AuthCredentialsStore {
+  static const _kPasswordKey = 'auth.password';
+  static const _kSimpleCookieKey = 'auth.simple.cookie';
+  static const _kUiAccessKey = 'auth.ui.accessToken';
+  static const _kUiRefreshKey = 'auth.ui.refreshToken';
+  static const _kBasicCredentialsKey = 'auth.basic.credentials';
+
+  @override
+  Future<AuthCredentialsState> build() async {
+    final storage = ref.read(secureStorageProvider);
+    final results = await Future.wait([
+      storage.read(key: _kPasswordKey),
+      storage.read(key: _kSimpleCookieKey),
+      storage.read(key: _kUiAccessKey),
+      storage.read(key: _kUiRefreshKey),
+    ]);
+    return AuthCredentialsState(
+      password: results[0],
+      simpleLoginCookie: results[1],
+      uiAccessToken: results[2],
+      uiRefreshToken: results[3],
+    );
+  }
+
+  /// Current snapshot, or `AuthCredentialsState.empty()` if `build()`
+  /// hasn't completed yet. Used internally by mutators that need to
+  /// apply `copyWith` even before the initial load finishes.
+  AuthCredentialsState get _current =>
+      state.valueOrNull ?? const AuthCredentialsState.empty();
+
+  // ---------- Password ----------
+
+  Future<void> savePassword(String password) async {
+    await ref
+        .read(secureStorageProvider)
+        .write(key: _kPasswordKey, value: password);
+    state = AsyncData(_current.copyWith(password: password));
+  }
+
+  Future<void> clearPassword() async {
+    await ref.read(secureStorageProvider).delete(key: _kPasswordKey);
+    state = AsyncData(_current.copyWith(clearPassword: true));
+  }
+
+  // ---------- Simple Login ----------
+
+  Future<void> saveSimpleLoginCookie(String cookieValue) async {
+    await ref.read(secureStorageProvider).write(
+          key: _kSimpleCookieKey,
+          value: cookieValue,
+        );
+    state = AsyncData(_current.copyWith(simpleLoginCookie: cookieValue));
+  }
+
+  Future<void> clearSimpleLoginCookie() async {
+    await ref.read(secureStorageProvider).delete(key: _kSimpleCookieKey);
+    state = AsyncData(_current.copyWith(clearSimpleLoginCookie: true));
+  }
+
+  // ---------- UI Login ----------
+
+  Future<void> saveUiLoginTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    final storage = ref.read(secureStorageProvider);
+    await storage.write(key: _kUiAccessKey, value: accessToken);
+    await storage.write(key: _kUiRefreshKey, value: refreshToken);
+    state = AsyncData(_current.copyWith(
+      uiAccessToken: accessToken,
+      uiRefreshToken: refreshToken,
+    ));
+  }
+
+  Future<void> updateUiLoginAccessToken(String accessToken) async {
+    await ref.read(secureStorageProvider).write(
+          key: _kUiAccessKey,
+          value: accessToken,
+        );
+    state = AsyncData(_current.copyWith(uiAccessToken: accessToken));
+  }
+
+  Future<void> clearUiLoginTokens() async {
+    final storage = ref.read(secureStorageProvider);
+    await storage.delete(key: _kUiAccessKey);
+    await storage.delete(key: _kUiRefreshKey);
+    state = AsyncData(_current.copyWith(
+      clearUiAccessToken: true,
+      clearUiRefreshToken: true,
+    ));
+  }
+
+  /// Returns the cached refresh+access pair from state, or `null` if
+  /// either is missing. Avoids hitting secure storage on every refresh.
+  UiLoginTokens? uiLoginTokens() {
+    final s = _current;
+    if (s.uiAccessToken == null || s.uiRefreshToken == null) return null;
+    return UiLoginTokens(
+      accessToken: s.uiAccessToken!,
+      refreshToken: s.uiRefreshToken!,
+    );
+  }
+
+  // ---------- Basic credentials (migrated from SharedPreferences) ----------
+
+  /// Removes the migrated basic-auth credential from secure storage.
+  /// We don't track it in `state` (it's not in `AuthCredentialsState`)
+  /// because basic auth has its own existing provider (`credentialsProvider`)
+  /// for read access — this method exists solely to give the Logout flow
+  /// a way to clear that entry post-migration.
+  Future<void> clearBasicCredentials() =>
+      ref.read(secureStorageProvider).delete(key: _kBasicCredentialsKey);
+}

--- a/lib/src/features/auth/data/auth_state.dart
+++ b/lib/src/features/auth/data/auth_state.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auth_state.g.dart';
+
+/// Tracks whether the current session has expired and the user needs to
+/// re-enter their password.
+///
+/// Set to `true` by:
+///   - `SuwayomiAuthLink` when a 401 cannot be resolved by refresh (UI Login)
+///   - `SuwayomiAuthLink` when a 401 arrives (Simple Login — no refresh path)
+///
+/// Cleared to `false` by `AuthCoordinator` after a successful re-login.
+///
+/// Watched by `ReauthBannerHost` to decide whether to surface the banner
+/// via `ScaffoldMessenger`.
+@Riverpod(keepAlive: true)
+class NeedsReauth extends _$NeedsReauth {
+  @override
+  bool build() => false;
+
+  void set(bool value) => state = value;
+}

--- a/lib/src/features/auth/data/basic_auth_migration.dart
+++ b/lib/src/features/auth/data/basic_auth_migration.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Secure-storage key under which basic-auth credentials now live.
+const kBasicCredentialsSecureKey = 'auth.basic.credentials';
+
+/// Legacy SharedPreferences key (DBKeys.basicCredentials.name).
+const _kLegacyBasicCredentialsKey = 'basicCredentials';
+
+/// One-time, idempotent migration of basic-auth credentials from the
+/// plaintext-equivalent SharedPreferences store to platform secure storage.
+///
+/// If a credential exists in the legacy location:
+///   - And nothing is in secure storage yet → move it.
+///   - And something is already in secure storage → keep the secure-store
+///     value (user may have re-entered credentials more recently); just
+///     clear the legacy copy.
+///
+/// Either way, the legacy SharedPreferences entry is deleted at the end so
+/// the plaintext copy doesn't linger.
+Future<void> migrateBasicAuthCredentials({
+  required SharedPreferences prefs,
+  required FlutterSecureStorage secure,
+}) async {
+  final legacy = prefs.getString(_kLegacyBasicCredentialsKey);
+  if (legacy == null) return;
+
+  final existing = await secure.read(key: kBasicCredentialsSecureKey);
+  if (existing == null) {
+    await secure.write(key: kBasicCredentialsSecureKey, value: legacy);
+  }
+  await prefs.remove(_kLegacyBasicCredentialsKey);
+}

--- a/lib/src/features/auth/data/graphql/auth.graphql
+++ b/lib/src/features/auth/data/graphql/auth.graphql
@@ -1,0 +1,12 @@
+mutation Login($input: LoginInput!) {
+  login(input: $input) {
+    accessToken
+    refreshToken
+  }
+}
+
+mutation RefreshToken($input: RefreshTokenInput!) {
+  refreshToken(input: $input) {
+    accessToken
+  }
+}

--- a/lib/src/features/auth/data/secure_credentials_provider.dart
+++ b/lib/src/features/auth/data/secure_credentials_provider.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'secure_credentials_provider.g.dart';
+
+/// A platform-backed secure key/value store for credentials.
+///
+/// On Android this is backed by EncryptedSharedPreferences (Keystore-backed
+/// AES key); on iOS by the Keychain; on desktop/web by best-available
+/// platform stores. Always preferred over SharedPreferences for anything
+/// bearer-equivalent (passwords, JWTs, session cookies).
+@Riverpod(keepAlive: true)
+FlutterSecureStorage secureStorage(Ref ref) => const FlutterSecureStorage(
+      aOptions: AndroidOptions(
+        encryptedSharedPreferences: true,
+      ),
+    );

--- a/lib/src/features/auth/data/simple_login_client.dart
+++ b/lib/src/features/auth/data/simple_login_client.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:http/http.dart' as http;
+
+/// Thrown when `POST /login.html` returns HTTP 200 (Suwayomi's way of
+/// signalling invalid credentials — it re-renders the login HTML).
+class SimpleLoginAuthFailure implements Exception {
+  const SimpleLoginAuthFailure();
+  @override
+  String toString() => 'SimpleLoginAuthFailure: invalid username/password';
+}
+
+/// Thrown when the response shape is neither the 303-redirect-with-cookie
+/// success path nor the 200-with-html failure path.
+class SimpleLoginShapeFailure implements Exception {
+  const SimpleLoginShapeFailure(this.message);
+  final String message;
+  @override
+  String toString() => 'SimpleLoginShapeFailure: $message';
+}
+
+/// Talks to Suwayomi-Server's `simple_login` auth mode.
+class SimpleLoginClient {
+  SimpleLoginClient({http.Client? httpClient})
+      : _http = httpClient ?? http.Client();
+
+  final http.Client _http;
+
+  /// POSTs username + password to `<serverBaseUrl>/login.html` and returns
+  /// the value of the `Set-Cookie` header (typically
+  /// `"JSESSIONID=<sessionId>"`) for the client to send on subsequent
+  /// requests.
+  ///
+  /// Throws [SimpleLoginAuthFailure] on credential rejection, or
+  /// [SimpleLoginShapeFailure] on any other server response.
+  Future<String> login({
+    required String serverBaseUrl,
+    required String username,
+    required String password,
+  }) async {
+    final uri = Uri.parse('$serverBaseUrl/login.html');
+    final response = await _http.post(
+      uri,
+      headers: {
+        'Content-Type':
+            'application/x-www-form-urlencoded; charset=utf-8',
+      },
+      body: {'user': username, 'pass': password},
+    );
+
+    if (response.statusCode == 200) {
+      // Server re-rendered the login page → bad credentials.
+      throw const SimpleLoginAuthFailure();
+    }
+    if (response.statusCode != 303) {
+      throw SimpleLoginShapeFailure(
+          'unexpected status ${response.statusCode}');
+    }
+    final setCookie = response.headers['set-cookie'];
+    if (setCookie == null || setCookie.isEmpty) {
+      throw const SimpleLoginShapeFailure(
+          '303 response had no Set-Cookie header');
+    }
+    // `Set-Cookie: JSESSIONID=abc; Path=/; HttpOnly` → keep just
+    // "JSESSIONID=abc" for the outgoing Cookie header on later requests.
+    return setCookie.split(';').first.trim();
+  }
+}

--- a/lib/src/features/auth/data/suwayomi_auth_link.dart
+++ b/lib/src/features/auth/data/suwayomi_auth_link.dart
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:graphql/client.dart';
+
+import '../../../constants/enum.dart';
+import 'auth_coordinator.dart';
+
+/// Custom GraphQL Link for Suwayomi's `simple_login` and `ui_login` modes.
+///
+/// Responsibilities:
+///   1. Inject auth headers (Authorization for ui_login, Cookie for
+///      simple_login) onto every outgoing request.
+///   2. On HTTP 401 responses:
+///      - ui_login: delegate refresh to [refreshAccessToken] (which is
+///        single-flighted at the AuthCoordinator layer — see R2-3 — so
+///        the query and subscription Links share one in-flight refresh).
+///        On success retry once; on auth failure surface the 401; on
+///        transient failure surface the original 401 unchanged.
+///      - simple_login: signal needs-reauth and bubble the 401 up. No
+///        refresh path exists for simple_login.
+///   3. Re-check the retried response for a second 401. If the retry
+///      also returns 401, treat as auth failure (clear tokens, set
+///      needs-reauth) and surface the 401 to the caller — R2-4.
+///
+/// **Subscription caveat (Codex round-3 finding):** This Link only
+/// inspects the FIRST event of each forwarded stream for 401. A
+/// long-lived GraphQL subscription that emits data successfully and
+/// THEN gets a 401 mid-stream (e.g. server-side session timeout while
+/// the WebSocket is open) will yield the 401 to the caller without
+/// triggering refresh. Suwayomi's GraphQL surface uses subscriptions
+/// only for server-status/download-progress, which are short-lived and
+/// rate-limited — the failure mode is mostly cosmetic (the next request
+/// will hit 401, trigger refresh, and resume). If a future Suwayomi
+/// version adds long-running subscriptions, this Link needs an
+/// inspect-every-event variant.
+class SuwayomiAuthLink extends Link {
+  SuwayomiAuthLink({
+    required this.authType,
+    required this.getHeaders,
+    required this.refreshAccessToken,
+    required this.onNeedsReauth,
+  });
+
+  /// Returns the current AuthType.
+  final AuthType Function() authType;
+
+  /// Returns the headers to inject for the current auth mode, or null if
+  /// nothing should be injected. Called per request.
+  final Future<Map<String, String>?> Function() getHeaders;
+
+  /// Performs a refresh and returns a typed [RefreshOutcome]. Called only
+  /// for ui_login on 401. The implementation in `AuthCoordinator`
+  /// handles single-flighting across both Link instances; this Link does
+  /// not need its own Completer.
+  final Future<RefreshOutcome> Function() refreshAccessToken;
+
+  /// Invoked when the link concludes the session is dead. Implementations
+  /// typically set NeedsReauth=true.
+  final void Function() onNeedsReauth;
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) async* {
+    final headers = await getHeaders();
+    final withHeaders = headers == null
+        ? request
+        : request.updateContextEntry<HttpLinkHeaders>(
+            (HttpLinkHeaders? entry) => HttpLinkHeaders(
+              headers: <String, String>{
+                ...?entry?.headers,
+                ...headers,
+              },
+            ),
+          );
+
+    // Iterate the forwarded stream. We inspect only the FIRST event to
+    // decide whether we have a 401 → retry case; every other event flows
+    // through unchanged. Using `await forward!(withHeaders).first` would
+    // cancel the subscription after one event, silently killing any
+    // GraphQL subscription that doesn't immediately fail.
+    Response? first401;
+    var sawFirst = false;
+    await for (final response in forward!(withHeaders)) {
+      if (!sawFirst) {
+        sawFirst = true;
+        if (_is401(response)) {
+          // Cache the 401 and break out to handle refresh/retry below.
+          // We're cancelling the upstream stream here — that's fine for
+          // queries/mutations (they only emit one response anyway) and
+          // for subscriptions a 401 means the server rejected the
+          // connection, so there's nothing useful to keep streaming.
+          first401 = response;
+          break;
+        }
+      }
+      yield response;
+    }
+
+    if (first401 == null) {
+      // Success path: stream already drained and yielded. Done.
+      return;
+    }
+
+    // 401 path.
+    if (authType() != AuthType.uiLogin) {
+      // simple_login has no refresh path.
+      onNeedsReauth();
+      yield first401;
+      return;
+    }
+
+    // ui_login: delegate refresh to AuthCoordinator. The coordinator
+    // owns the single-flight Completer (R2-3) so concurrent 401s in the
+    // query and subscription clients share one refresh.
+    final outcome = await refreshAccessToken();
+    switch (outcome) {
+      case RefreshAuthFailure():
+        // Refresh token rejected. Tokens already cleared by the
+        // coordinator. Surface the original 401.
+        onNeedsReauth();
+        yield first401;
+        return;
+      case RefreshTransientFailure():
+        // Network / server error — DON'T mark session as dead. Surface
+        // the original 401 so the UI shows a normal error; the next
+        // request will trigger another refresh attempt.
+        yield first401;
+        return;
+      case RefreshSuccess(:final newAccessToken):
+        // Retry once with the fresh token. R2-4: re-check the retried
+        // response for a second 401. If it's still 401, the new token
+        // didn't work either — treat as auth failure.
+        final retried = request.updateContextEntry<HttpLinkHeaders>(
+          (HttpLinkHeaders? entry) => HttpLinkHeaders(
+            headers: <String, String>{
+              ...?entry?.headers,
+              'Authorization': 'Bearer $newAccessToken',
+            },
+          ),
+        );
+        Response? retryFirst401;
+        var sawRetryFirst = false;
+        await for (final response in forward(retried)) {
+          if (!sawRetryFirst) {
+            sawRetryFirst = true;
+            if (_is401(response)) {
+              retryFirst401 = response;
+              break;
+            }
+          }
+          yield response;
+        }
+        if (retryFirst401 != null) {
+          // Second 401 after a fresh token = something's off (server
+          // rotated mid-flight, fresh token rejected, etc). Clear and
+          // require re-auth.
+          onNeedsReauth();
+          yield retryFirst401;
+        }
+        return;
+    }
+  }
+
+  bool _is401(Response response) {
+    final errors = response.errors;
+    if (errors == null) return false;
+    for (final err in errors) {
+      final http = err.extensions?['http'] as Map?;
+      final status = http?['status'];
+      if (status == 401) return true;
+      if (err.message.toLowerCase().contains('unauthor')) return true;
+    }
+    return false;
+  }
+}

--- a/lib/src/features/auth/presentation/reauth_banner.dart
+++ b/lib/src/features/auth/presentation/reauth_banner.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../constants/enum.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../settings/presentation/server/widget/credential_popup/login_credentials_popup.dart';
+import '../data/auth_state.dart';
+
+/// Layout-neutral host that surfaces a re-auth `MaterialBanner` via
+/// `ScaffoldMessenger` when the session has expired. Returns its child
+/// unchanged — safe to wrap around `CustomScrollView` or sliver layouts.
+class ReauthBannerHost extends ConsumerStatefulWidget {
+  const ReauthBannerHost({super.key, required this.child});
+  final Widget child;
+
+  @override
+  ConsumerState<ReauthBannerHost> createState() => _ReauthBannerHostState();
+}
+
+class _ReauthBannerHostState extends ConsumerState<ReauthBannerHost> {
+  bool _bannerShown = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (ref.read(needsReauthProvider)) _showBanner();
+    });
+  }
+
+  void _showBanner() {
+    if (_bannerShown) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    _bannerShown = true;
+    messenger.clearMaterialBanners();
+    messenger.showMaterialBanner(_buildBanner());
+  }
+
+  void _clearBanner() {
+    if (!_bannerShown) return;
+    _bannerShown = false;
+    ScaffoldMessenger.maybeOf(context)?.clearMaterialBanners();
+  }
+
+  MaterialBanner _buildBanner() {
+    final authType = ref.read(authTypeKeyProvider);
+    return MaterialBanner(
+      content: Text(context.l10n.authSessionExpired),
+      leading: const Icon(Icons.warning_amber_rounded),
+      actions: [
+        TextButton(
+          onPressed: () {
+            if (authType == AuthType.simpleLogin ||
+                authType == AuthType.uiLogin) {
+              showDialog(
+                context: context,
+                builder: (_) => LoginCredentialsPopup(authType: authType!),
+              );
+            }
+          },
+          child: Text(context.l10n.authReauthenticate),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<bool>(needsReauthProvider, (prev, next) {
+      if (next) {
+        _showBanner();
+      } else {
+        _clearBanner();
+      }
+    });
+    return widget.child;
+  }
+}

--- a/lib/src/features/settings/presentation/server/widget/authentication/authentication_section.dart
+++ b/lib/src/features/settings/presentation/server/widget/authentication/authentication_section.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../../../constants/enum.dart';
+import '../../../../../../features/auth/data/auth_credentials_store.dart';
+import '../../../../../../features/auth/data/auth_state.dart';
 import '../../../../../../global_providers/global_providers.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../widgets/section_title.dart';
 import '../credential_popup/credentials_popup.dart';
+import '../credential_popup/login_credentials_popup.dart';
 import 'auth_type/auth_type_tile.dart';
 
 class AuthenticationSection extends ConsumerWidget {
@@ -19,17 +22,68 @@ class AuthenticationSection extends ConsumerWidget {
       children: [
         SectionTitle(title: context.l10n.authentication),
         const AuthTypeTile(),
-        if (authType != null && authType != AuthType.none)
+        if (authType != null && authType != AuthType.none) ...[
           ListTile(
             leading: const Icon(Icons.password_rounded),
             title: Text(context.l10n.credentials),
             onTap: () {
               showDialog(
                 context: context,
-                builder: (context) => const CredentialsPopup(),
+                builder: (context) => switch (authType) {
+                  AuthType.basic => const CredentialsPopup(),
+                  AuthType.simpleLogin =>
+                    const LoginCredentialsPopup(authType: AuthType.simpleLogin),
+                  AuthType.uiLogin =>
+                    const LoginCredentialsPopup(authType: AuthType.uiLogin),
+                  AuthType.none => const SizedBox.shrink(),
+                },
               );
             },
           ),
+          ListTile(
+            leading: Icon(
+              Icons.logout_rounded,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            title: Text(
+              context.l10n.authLogout,
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+            onTap: () async {
+              final confirmed = await showDialog<bool>(
+                context: context,
+                builder: (dialogCtx) => AlertDialog(
+                  title: Text(context.l10n.authLogout),
+                  content: Text(context.l10n.authLogoutConfirm),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(dialogCtx, false),
+                      child: Text(context.l10n.cancel),
+                    ),
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor:
+                            Theme.of(context).colorScheme.error,
+                        foregroundColor:
+                            Theme.of(context).colorScheme.onError,
+                      ),
+                      onPressed: () => Navigator.pop(dialogCtx, true),
+                      child: Text(context.l10n.authLogout),
+                    ),
+                  ],
+                ),
+              );
+              if (confirmed != true) return;
+              final store = ref.read(authCredentialsStoreProvider.notifier);
+              await store.clearUiLoginTokens();
+              await store.clearSimpleLoginCookie();
+              await store.clearPassword();
+              await store.clearBasicCredentials();
+              ref.read(authTypeKeyProvider.notifier).update(AuthType.none);
+              ref.read(needsReauthProvider.notifier).set(false);
+            },
+          ),
+        ],
       ],
     );
   }

--- a/lib/src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart
+++ b/lib/src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart
@@ -12,18 +12,28 @@ import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../../../../constants/db_keys.dart';
+import '../../../../../../features/auth/data/basic_auth_migration.dart';
+import '../../../../../../features/auth/data/secure_credentials_provider.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
-import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../../../widgets/popup_widgets/pop_button.dart';
 
 part 'credentials_popup.g.dart';
 
 @riverpod
-class Credentials extends _$Credentials
-    with SharedPreferenceClientMixin<String> {
+class Credentials extends _$Credentials {
   @override
-  String? build() => initialize(DBKeys.basicCredentials);
+  Future<String?> build() async =>
+      ref.read(secureStorageProvider).read(key: kBasicCredentialsSecureKey);
+
+  Future<void> set(String? value) async {
+    state = AsyncData(value);
+    final storage = ref.read(secureStorageProvider);
+    if (value == null) {
+      await storage.delete(key: kBasicCredentialsSecureKey);
+    } else {
+      await storage.write(key: kBasicCredentialsSecureKey, value: value);
+    }
+  }
 }
 
 final formKey = GlobalKey<FormState>();
@@ -78,7 +88,7 @@ class CredentialsPopup extends HookConsumerWidget {
         ElevatedButton(
           onPressed: () async {
             if ((formKey.currentState?.validate()).ifNull()) {
-              ref.read(credentialsProvider.notifier).update(
+              ref.read(credentialsProvider.notifier).set(
                     _basicAuth(
                       userName: username.text,
                       password: password.text,

--- a/lib/src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart
+++ b/lib/src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:gap/gap.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../constants/endpoints.dart';
+import '../../../../../../constants/enum.dart';
+import '../../../../../../features/auth/data/auth_coordinator.dart';
+import '../../../../../../features/auth/data/auth_credentials_store.dart';
+import '../../../../../../global_providers/global_providers.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+import '../../../../../../widgets/popup_widgets/pop_button.dart';
+import '../client/server_port_tile/server_port_tile.dart';
+import '../client/server_url_tile/server_url_tile.dart';
+
+part 'login_credentials_popup.g.dart';
+
+@riverpod
+class AuthUsername extends _$AuthUsername
+    with SharedPreferenceClientMixin<String> {
+  @override
+  String? build() => initialize(DBKeys.authUsername);
+}
+
+class LoginCredentialsPopup extends HookConsumerWidget {
+  const LoginCredentialsPopup({super.key, required this.authType});
+
+  final AuthType authType;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = useMemoized(() => GlobalKey<FormState>());
+    final username = useTextEditingController(
+      text: ref.read(authUsernameProvider) ?? '',
+    );
+    final password = useTextEditingController();
+    final testing = useState(false);
+    final testResult = useState<String?>(null);
+    final testResultIsError = useState(false);
+
+    Future<bool> confirmInsecureIfNeeded(String resolvedUrl) async {
+      if (!resolvedUrl.startsWith('http://')) return true;
+      final proceed = await showDialog<bool>(
+        context: context,
+        builder: (dialogCtx) => AlertDialog(
+          icon: const Icon(Icons.warning_amber_rounded),
+          title: Text(context.l10n.authInsecureTransportTitle),
+          content: Text(context.l10n.authInsecureTransportWarning),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogCtx, false),
+              child: Text(context.l10n.cancel),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.error,
+                foregroundColor: Theme.of(context).colorScheme.onError,
+              ),
+              onPressed: () => Navigator.pop(dialogCtx, true),
+              child: Text(context.l10n.authInsecureTransportContinue),
+            ),
+          ],
+        ),
+      );
+      return proceed == true;
+    }
+
+    String resolveBaseUrl() {
+      final baseUrl =
+          ref.read(serverUrlProvider) ?? DBKeys.serverUrl.initial;
+      return Endpoints.baseApi(
+        baseUrl: baseUrl,
+        port: ref.read(serverPortProvider),
+        addPort: ref.read(serverPortToggleProvider).ifNull(),
+      );
+    }
+
+    Future<void> doTest() async {
+      if (!(formKey.currentState?.validate()).ifNull()) return;
+      testing.value = true;
+      testResult.value = null;
+      try {
+        final resolvedUrl = resolveBaseUrl();
+        if (!await confirmInsecureIfNeeded(resolvedUrl)) {
+          if (!context.mounted) return;
+          testing.value = false;
+          return;
+        }
+        final result = await ref
+            .read(authCoordinatorProvider.notifier)
+            .testConnection(
+              authType: authType,
+              serverBaseUrl: resolvedUrl,
+              username: username.text,
+              password: password.text,
+              makeGqlClient: () => ref.read(graphQlClientProvider),
+            );
+        if (!context.mounted) return;
+        if (result is TestConnectionSuccess) {
+          testResult.value = context.l10n.authTestConnectionSuccess;
+          testResultIsError.value = false;
+        } else if (result is TestConnectionFailure) {
+          testResultIsError.value = true;
+          testResult.value = switch (result.kind) {
+            TestConnectionFailureKind.network =>
+              context.l10n.authTestConnectionFailedNetwork,
+            TestConnectionFailureKind.invalidCredentials =>
+              context.l10n.authTestConnectionFailedAuth,
+            TestConnectionFailureKind.wrongAuthMode =>
+              context.l10n.authTestConnectionFailedMode,
+            TestConnectionFailureKind.unexpectedShape =>
+              context.l10n.authTestConnectionFailedShape,
+            TestConnectionFailureKind.insecureTransport =>
+              context.l10n.authInsecureTransportWarning,
+          };
+        }
+      } finally {
+        if (context.mounted) testing.value = false;
+      }
+    }
+
+    Future<void> doSave() async {
+      if (!(formKey.currentState?.validate()).ifNull()) return;
+      testing.value = true;
+      testResult.value = null;
+      try {
+        final resolvedUrl = resolveBaseUrl();
+        if (!await confirmInsecureIfNeeded(resolvedUrl)) {
+          if (!context.mounted) return;
+          testing.value = false;
+          return;
+        }
+        ref.read(authUsernameProvider.notifier).update(username.text);
+        final store = ref.read(authCredentialsStoreProvider.notifier);
+        final coordinator = ref.read(authCoordinatorProvider.notifier);
+        if (authType == AuthType.simpleLogin) {
+          await store.clearUiLoginTokens();
+          await store.clearBasicCredentials();
+          await coordinator.loginSimple(
+            serverBaseUrl: resolvedUrl,
+            username: username.text,
+            password: password.text,
+          );
+        } else if (authType == AuthType.uiLogin) {
+          await store.clearSimpleLoginCookie();
+          await store.clearBasicCredentials();
+          await coordinator.loginUi(
+            gqlClient: ref.read(graphQlClientProvider),
+            username: username.text,
+            password: password.text,
+          );
+        }
+        if (context.mounted) Navigator.pop(context);
+      } catch (e) {
+        if (!context.mounted) return;
+        testResultIsError.value = true;
+        testResult.value = e.toString();
+      } finally {
+        if (context.mounted) testing.value = false;
+      }
+    }
+
+    return AlertDialog(
+      title: Text(context.l10n.credentials),
+      content: Form(
+        key: formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextFormField(
+              controller: username,
+              validator: (v) => v.isBlank ? context.l10n.errorUserName : null,
+              decoration: InputDecoration(
+                hintText: context.l10n.userName,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+            const Gap(4),
+            TextFormField(
+              controller: password,
+              validator: (v) => v.isBlank ? context.l10n.errorPassword : null,
+              obscureText: true,
+              decoration: InputDecoration(
+                hintText: context.l10n.password,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+            const Gap(12),
+            Text(
+              context.l10n.authReverseProxyHelp,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).hintColor,
+                  ),
+            ),
+            if (authType == AuthType.uiLogin) ...[
+              const Gap(8),
+              Text(
+                context.l10n.authImageUrlLogWarning,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).hintColor,
+                    ),
+              ),
+            ],
+            if (testResult.value != null) ...[
+              const Gap(8),
+              Text(
+                testResult.value!,
+                style: TextStyle(
+                  color: testResultIsError.value
+                      ? Theme.of(context).colorScheme.error
+                      : Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        const PopButton(),
+        TextButton(
+          onPressed: testing.value ? null : doTest,
+          child: testing.value
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(context.l10n.authTestConnection),
+        ),
+        ElevatedButton(
+          onPressed: testing.value ? null : doSave,
+          child: Text(context.l10n.save),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart
+++ b/lib/src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
@@ -49,6 +50,7 @@ class LoginCredentialsPopup extends HookConsumerWidget {
 
     Future<bool> confirmInsecureIfNeeded(String resolvedUrl) async {
       if (!resolvedUrl.startsWith('http://')) return true;
+      if (isLocalAddress(resolvedUrl)) return true;
       final proceed = await showDialog<bool>(
         context: context,
         builder: (dialogCtx) => AlertDialog(
@@ -110,18 +112,7 @@ class LoginCredentialsPopup extends HookConsumerWidget {
           testResultIsError.value = false;
         } else if (result is TestConnectionFailure) {
           testResultIsError.value = true;
-          testResult.value = switch (result.kind) {
-            TestConnectionFailureKind.network =>
-              context.l10n.authTestConnectionFailedNetwork,
-            TestConnectionFailureKind.invalidCredentials =>
-              context.l10n.authTestConnectionFailedAuth,
-            TestConnectionFailureKind.wrongAuthMode =>
-              context.l10n.authTestConnectionFailedMode,
-            TestConnectionFailureKind.unexpectedShape =>
-              context.l10n.authTestConnectionFailedShape,
-            TestConnectionFailureKind.insecureTransport =>
-              context.l10n.authInsecureTransportWarning,
-          };
+          testResult.value = _failureMessage(context, result.kind);
         }
       } finally {
         if (context.mounted) testing.value = false;
@@ -163,7 +154,7 @@ class LoginCredentialsPopup extends HookConsumerWidget {
       } catch (e) {
         if (!context.mounted) return;
         testResultIsError.value = true;
-        testResult.value = e.toString();
+        testResult.value = _failureMessage(context, classifyAuthError(e).kind);
       } finally {
         if (context.mounted) testing.value = false;
       }
@@ -212,12 +203,17 @@ class LoginCredentialsPopup extends HookConsumerWidget {
             ],
             if (testResult.value != null) ...[
               const Gap(8),
-              Text(
-                testResult.value!,
-                style: TextStyle(
-                  color: testResultIsError.value
-                      ? Theme.of(context).colorScheme.error
-                      : Theme.of(context).colorScheme.primary,
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 120),
+                child: SingleChildScrollView(
+                  child: SelectableText(
+                    testResult.value!,
+                    style: TextStyle(
+                      color: testResultIsError.value
+                          ? Theme.of(context).colorScheme.error
+                          : Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
                 ),
               ),
             ],
@@ -243,4 +239,43 @@ class LoginCredentialsPopup extends HookConsumerWidget {
       ],
     );
   }
+}
+
+/// True for LAN-only hosts where plaintext HTTP is the norm: localhost,
+/// 127.x, and RFC1918 IPv4 ranges. We suppress the "Insecure connection"
+/// dialog for these because the warning was meant for the open internet,
+/// not a 192.168.x.x server. Exposed (not _-prefixed) so the test can
+/// exercise the address-matching logic without driving the dialog.
+@visibleForTesting
+bool isLocalAddress(String url) {
+  final host = Uri.tryParse(url)?.host.toLowerCase();
+  if (host == null || host.isEmpty) return false;
+  if (host == 'localhost') return true;
+  final parts = host.split('.');
+  if (parts.length != 4) return false;
+  final octets = parts.map(int.tryParse).toList();
+  if (octets.any((o) => o == null || o < 0 || o > 255)) return false;
+  final a = octets[0]!;
+  final b = octets[1]!;
+  if (a == 127) return true; // 127.0.0.0/8
+  if (a == 10) return true; // 10.0.0.0/8
+  if (a == 192 && b == 168) return true; // 192.168.0.0/16
+  if (a == 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  return false;
+}
+
+String _failureMessage(BuildContext context, TestConnectionFailureKind kind) {
+  return switch (kind) {
+    TestConnectionFailureKind.network =>
+      context.l10n.authTestConnectionFailedNetwork,
+    TestConnectionFailureKind.tls => context.l10n.authTestConnectionFailedTls,
+    TestConnectionFailureKind.invalidCredentials =>
+      context.l10n.authTestConnectionFailedAuth,
+    TestConnectionFailureKind.wrongAuthMode =>
+      context.l10n.authTestConnectionFailedMode,
+    TestConnectionFailureKind.unexpectedShape =>
+      context.l10n.authTestConnectionFailedShape,
+    TestConnectionFailureKind.insecureTransport =>
+      context.l10n.authInsecureTransportWarning,
+  };
 }

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -14,6 +14,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../constants/db_keys.dart';
 import '../constants/endpoints.dart';
 import '../constants/enum.dart';
+import '../features/auth/data/auth_coordinator.dart';
+import '../features/auth/data/auth_credentials_store.dart';
+import '../features/auth/data/auth_state.dart';
+import '../features/auth/data/suwayomi_auth_link.dart';
 import '../features/settings/presentation/general/timeout_settings/timeout_settings_section.dart';
 import '../features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
@@ -64,10 +68,56 @@ GraphQLClient graphQlClient(Ref ref) {
 
   // Auto retry is handled by TimeoutHttpClient retries instead of RetryLink
 
-  // Basic authentication link
+  // Basic authentication link (unchanged).
   if (authType == AuthType.basic && credentials.isNotBlank) {
     final AuthLink authLink = AuthLink(getToken: () => credentials);
     link = authLink.concat(link);
+  }
+
+  // simple_login / ui_login link.
+  if (authType == AuthType.simpleLogin || authType == AuthType.uiLogin) {
+    final suwayomiAuthLink = SuwayomiAuthLink(
+      authType: () => authType,
+      getHeaders: () async {
+        // Synchronously read the cached snapshot — populated at startup
+        // by the eager `await container.read(...future)` in main(). We
+        // read via `.future` defensively in case a caller invokes a
+        // GraphQL operation before the preload finishes.
+        final snapshot =
+            await ref.read(authCredentialsStoreProvider.future);
+        return authType == AuthType.simpleLogin
+            ? snapshot.simpleLoginCookieHeader
+            : snapshot.uiAuthorizationHeader;
+      },
+      refreshAccessToken: () async {
+        // Refresh path only applies to ui_login. For simple_login the
+        // Link short-circuits before invoking this callback, so any
+        // value works; AuthFailure is the most semantically truthful.
+        if (authType != AuthType.uiLogin) {
+          return const RefreshAuthFailure();
+        }
+        // Use a NON-authed GraphQL client to avoid recursion: the refresh
+        // mutation must NOT go through SuwayomiAuthLink itself. The
+        // AuthCoordinator owns single-flight dedup (R2-3), so both Link
+        // instances (query + subscription) share one refresh through it.
+        final rawClient = GraphQLClient(
+          link: HttpLink(Endpoints.baseApi(
+            baseUrl: ref.read(serverUrlProvider) ?? DBKeys.serverUrl.initial,
+            port: ref.read(serverPortProvider),
+            addPort: ref.read(serverPortToggleProvider).ifNull(),
+            isGraphQl: true,
+          )),
+          cache: GraphQLCache(),
+        );
+        return await ref
+            .read(authCoordinatorProvider.notifier)
+            .refreshUiAccessToken(gqlClient: rawClient);
+      },
+      onNeedsReauth: () {
+        ref.read(needsReauthProvider.notifier).set(true);
+      },
+    );
+    link = suwayomiAuthLink.concat(link);
   }
 
   final loggerLink = LoggerLink();
@@ -97,6 +147,48 @@ GraphQLClient graphQlSubscriptionClient(Ref ref) {
     final AuthLink authLink = AuthLink(getToken: () => credentials);
     link = authLink.concat(link);
   }
+
+  if (authType == AuthType.simpleLogin || authType == AuthType.uiLogin) {
+    final suwayomiAuthLink = SuwayomiAuthLink(
+      authType: () => authType,
+      getHeaders: () async {
+        // Synchronously read the cached snapshot — populated at startup
+        // by the eager `await container.read(...future)` in main(). We
+        // read via `.future` defensively in case a caller invokes a
+        // GraphQL operation before the preload finishes.
+        final snapshot =
+            await ref.read(authCredentialsStoreProvider.future);
+        return authType == AuthType.simpleLogin
+            ? snapshot.simpleLoginCookieHeader
+            : snapshot.uiAuthorizationHeader;
+      },
+      refreshAccessToken: () async {
+        // Round-3 fix: signature is `Future<RefreshOutcome>`, must not
+        // return `null`. For non-uiLogin the Link short-circuits before
+        // this callback, but the type system still requires a value.
+        if (authType != AuthType.uiLogin) {
+          return const RefreshAuthFailure();
+        }
+        final rawClient = GraphQLClient(
+          link: HttpLink(Endpoints.baseApi(
+            baseUrl: ref.read(serverUrlProvider) ?? DBKeys.serverUrl.initial,
+            port: ref.read(serverPortProvider),
+            addPort: ref.read(serverPortToggleProvider).ifNull(),
+            isGraphQl: true,
+          )),
+          cache: GraphQLCache(),
+        );
+        return await ref
+            .read(authCoordinatorProvider.notifier)
+            .refreshUiAccessToken(gqlClient: rawClient);
+      },
+      onNeedsReauth: () {
+        ref.read(needsReauthProvider.notifier).set(true);
+      },
+    );
+    link = suwayomiAuthLink.concat(link);
+  }
+
   final loggerLink = LoggerLink();
   return GraphQLClient(
     link: loggerLink.concat(link),

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -134,60 +134,53 @@ GraphQLClient graphQlClient(Ref ref) {
 GraphQLClient graphQlSubscriptionClient(Ref ref) {
   final authType = ref.watch(authTypeKeyProvider) ?? DBKeys.authType.initial;
   final credentials = ref.watch(credentialsProvider).valueOrNull;
-  Link link = WebSocketLink(
-      Endpoints.baseApi(
-        baseUrl: ref.watch(serverUrlProvider) ?? DBKeys.serverUrl.initial,
-        port: ref.watch(serverPortProvider),
-        addPort: ref.watch(serverPortToggleProvider).ifNull(),
-        isGraphQl: true,
-        isWebsocket: true,
-      ),
-      subProtocol: GraphQLProtocol.graphqlTransportWs);
-  if (authType == AuthType.basic && credentials.isNotBlank) {
-    final AuthLink authLink = AuthLink(getToken: () => credentials);
-    link = authLink.concat(link);
+  final wsUrl = Endpoints.baseApi(
+    baseUrl: ref.watch(serverUrlProvider) ?? DBKeys.serverUrl.initial,
+    port: ref.watch(serverPortProvider),
+    addPort: ref.watch(serverPortToggleProvider).ifNull(),
+    isGraphQl: true,
+    isWebsocket: true,
+  );
+
+  // Authenticate the SOCKET itself, not a per-operation Link. A header /
+  // context Link (AuthLink / SuwayomiAuthLink) never reaches the WebSocket,
+  // so it leaves the connection unauthenticated and any @requireAuth
+  // subscription (e.g. downloadStatusChanged) fails with "Unauthorized" —
+  // while auth-exempt subscriptions (updateStatusChanged) still work, which
+  // is what made this look downloads-specific.
+  //
+  // graphql-transport-ws carries auth two ways, matching Suwayomi-Server:
+  //   * ui_login  -> connection_init payload `{Authorization: <bare token>}`
+  //                  (server `onInit` does NOT strip "Bearer "; the WebUI
+  //                  sends the bare token, so we do too).
+  //   * simple_login / basic -> the WS handshake (upgrade) headers.
+  dynamic initialPayload;
+  Map<String, String>? handshakeHeaders;
+  if (authType == AuthType.uiLogin) {
+    initialPayload = () async {
+      final snapshot = await ref.read(authCredentialsStoreProvider.future);
+      final token = snapshot.uiAccessToken;
+      return (token == null || token.isEmpty)
+          ? <String, dynamic>{}
+          : <String, dynamic>{'Authorization': token};
+    };
+  } else if (authType == AuthType.simpleLogin) {
+    handshakeHeaders = ref
+        .read(authCredentialsStoreProvider)
+        .valueOrNull
+        ?.simpleLoginCookieHeader;
+  } else if (authType == AuthType.basic && credentials.isNotBlank) {
+    handshakeHeaders = {'Authorization': credentials!};
   }
 
-  if (authType == AuthType.simpleLogin || authType == AuthType.uiLogin) {
-    final suwayomiAuthLink = SuwayomiAuthLink(
-      authType: () => authType,
-      getHeaders: () async {
-        // Synchronously read the cached snapshot — populated at startup
-        // by the eager `await container.read(...future)` in main(). We
-        // read via `.future` defensively in case a caller invokes a
-        // GraphQL operation before the preload finishes.
-        final snapshot =
-            await ref.read(authCredentialsStoreProvider.future);
-        return authType == AuthType.simpleLogin
-            ? snapshot.simpleLoginCookieHeader
-            : snapshot.uiAuthorizationHeader;
-      },
-      refreshAccessToken: () async {
-        // Round-3 fix: signature is `Future<RefreshOutcome>`, must not
-        // return `null`. For non-uiLogin the Link short-circuits before
-        // this callback, but the type system still requires a value.
-        if (authType != AuthType.uiLogin) {
-          return const RefreshAuthFailure();
-        }
-        final rawClient = GraphQLClient(
-          link: HttpLink(Endpoints.baseApi(
-            baseUrl: ref.read(serverUrlProvider) ?? DBKeys.serverUrl.initial,
-            port: ref.read(serverPortProvider),
-            addPort: ref.read(serverPortToggleProvider).ifNull(),
-            isGraphQl: true,
-          )),
-          cache: GraphQLCache(),
-        );
-        return await ref
-            .read(authCoordinatorProvider.notifier)
-            .refreshUiAccessToken(gqlClient: rawClient);
-      },
-      onNeedsReauth: () {
-        ref.read(needsReauthProvider.notifier).set(true);
-      },
-    );
-    link = suwayomiAuthLink.concat(link);
-  }
+  final Link link = WebSocketLink(
+    wsUrl,
+    subProtocol: GraphQLProtocol.graphqlTransportWs,
+    config: SocketClientConfig(
+      initialPayload: initialPayload,
+      headers: handshakeHeaders,
+    ),
+  );
 
   final loggerLink = LoggerLink();
   return GraphQLClient(

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -28,7 +28,7 @@ part 'global_providers.g.dart';
 @riverpod
 GraphQLClient graphQlClient(Ref ref) {
   final authType = ref.watch(authTypeKeyProvider) ?? DBKeys.authType.initial;
-  final credentials = ref.watch(credentialsProvider);
+  final credentials = ref.watch(credentialsProvider).valueOrNull;
 
   // Timeout settings
   final timeoutMs = ref.watch(serverRequestTimeoutProvider) ??
@@ -83,7 +83,7 @@ GraphQLClient graphQlClient(Ref ref) {
 @riverpod
 GraphQLClient graphQlSubscriptionClient(Ref ref) {
   final authType = ref.watch(authTypeKeyProvider) ?? DBKeys.authType.initial;
-  final credentials = ref.watch(credentialsProvider);
+  final credentials = ref.watch(credentialsProvider).valueOrNull;
   Link link = WebSocketLink(
       Endpoints.baseApi(
         baseUrl: ref.watch(serverUrlProvider) ?? DBKeys.serverUrl.initial,

--- a/lib/src/graphql/schema.graphql
+++ b/lib/src/graphql/schema.graphql
@@ -1,3 +1,6 @@
+"""Requires user authentication"""
+directive @requireAuth on OBJECT | FIELD_DEFINITION
+
 """Exposes a URL that specifies the behaviour of this scalar."""
 directive @specifiedBy(
   """The URL that specifies the behaviour of this scalar."""
@@ -13,13 +16,21 @@ type AboutServerPayload {
   discord: String!
   github: String!
   name: String!
-  revision: String!
+  revision: String! @deprecated(reason: "The version includes the revision as the patch number")
   version: String!
 }
 
 type AboutWebUI {
-  channel: String!
+  channel: WebUIChannel!
   tag: String!
+  updateTimestamp: LongString!
+}
+
+enum AuthMode {
+  NONE
+  BASIC_AUTH
+  SIMPLE_LOGIN
+  UI_LOGIN
 }
 
 enum BackupRestoreState {
@@ -28,6 +39,8 @@ enum BackupRestoreState {
   FAILURE
   RESTORING_CATEGORIES
   RESTORING_MANGA
+  RESTORING_META
+  RESTORING_SETTINGS
 }
 
 type BackupRestoreStatus {
@@ -39,6 +52,11 @@ type BackupRestoreStatus {
 input BindTrackInput {
   clientMutationId: String
   mangaId: Int!
+
+  """
+  This will only work if the tracker of the track record supports private tracking
+  """
+  private: Boolean
   remoteId: LongString!
   trackerId: Int!
 }
@@ -88,6 +106,11 @@ input CategoryFilterInput {
   order: IntFilterInput
 }
 
+enum CategoryJobStatus {
+  UPDATING
+  SKIPPED
+}
+
 type CategoryMetaType implements MetaType {
   categoryId: Int!
   key: String!
@@ -130,6 +153,17 @@ type CategoryType {
   meta: [CategoryMetaType!]!
 }
 
+type CategoryUpdateType {
+  category: CategoryType!
+  status: CategoryJobStatus!
+}
+
+enum CbzMediaType {
+  MODERN
+  LEGACY
+  COMPATIBLE
+}
+
 input ChapterConditionInput {
   chapterNumber: Float
   fetchedAt: LongString
@@ -156,7 +190,7 @@ type ChapterEdge implements Edge {
 
 input ChapterFilterInput {
   and: [ChapterFilterInput!]
-  chapterNumber: FloatFilterInput
+  chapterNumber: DoubleFilterInput
   fetchedAt: LongFilterInput
   id: IntFilterInput
   inLibrary: BooleanFilterInput
@@ -241,9 +275,10 @@ type CheckBoxFilter {
 type CheckBoxPreference {
   currentValue: Boolean
   default: Boolean!
-  key: String!
+  enabled: Boolean!
+  key: String
   summary: String
-  title: String!
+  title: String
   visible: Boolean!
 }
 
@@ -276,10 +311,16 @@ type ClearDownloaderPayload {
   downloadStatus: DownloadStatus!
 }
 
+input ConnectKoSyncAccountInput {
+  clientMutationId: String
+  password: String!
+  serverAddress: String!
+  username: String!
+}
+
 input CreateBackupInput {
   clientMutationId: String
-  includeCategories: Boolean
-  includeChapters: Boolean
+  flags: PartialBackupFlagsInput
 }
 
 type CreateBackupPayload {
@@ -304,6 +345,11 @@ type CreateCategoryPayload {
 """A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
+enum DatabaseType {
+  H2
+  POSTGRESQL
+}
+
 input DeleteCategoryInput {
   categoryId: Int!
   clientMutationId: String
@@ -319,6 +365,23 @@ type DeleteCategoryMetaPayload {
   category: CategoryType!
   clientMutationId: String
   meta: CategoryMetaType
+}
+
+input DeleteCategoryMetasInput {
+  clientMutationId: String
+  items: [DeleteCategoryMetasItemInput!]!
+}
+
+input DeleteCategoryMetasItemInput {
+  categoryIds: [Int!]!
+  keys: [String!]
+  prefixes: [String!]
+}
+
+type DeleteCategoryMetasPayload {
+  categories: [CategoryType!]!
+  clientMutationId: String
+  metas: [CategoryMetaType!]!
 }
 
 type DeleteCategoryPayload {
@@ -337,6 +400,23 @@ type DeleteChapterMetaPayload {
   chapter: ChapterType!
   clientMutationId: String
   meta: ChapterMetaType
+}
+
+input DeleteChapterMetasInput {
+  clientMutationId: String
+  items: [DeleteChapterMetasItemInput!]!
+}
+
+input DeleteChapterMetasItemInput {
+  chapterIds: [Int!]!
+  keys: [String!]
+  prefixes: [String!]
+}
+
+type DeleteChapterMetasPayload {
+  chapters: [ChapterType!]!
+  clientMutationId: String
+  metas: [ChapterMetaType!]!
 }
 
 input DeleteDownloadedChapterInput {
@@ -369,6 +449,17 @@ type DeleteGlobalMetaPayload {
   meta: GlobalMetaType
 }
 
+input DeleteGlobalMetasInput {
+  clientMutationId: String
+  keys: [String!]
+  prefixes: [String!]
+}
+
+type DeleteGlobalMetasPayload {
+  clientMutationId: String
+  metas: [GlobalMetaType!]!
+}
+
 input DeleteMangaMetaInput {
   clientMutationId: String
   key: String!
@@ -381,6 +472,23 @@ type DeleteMangaMetaPayload {
   meta: MangaMetaType
 }
 
+input DeleteMangaMetasInput {
+  clientMutationId: String
+  items: [DeleteMangaMetasItemInput!]!
+}
+
+input DeleteMangaMetasItemInput {
+  keys: [String!]
+  mangaIds: [Int!]!
+  prefixes: [String!]
+}
+
+type DeleteMangaMetasPayload {
+  clientMutationId: String
+  mangas: [MangaType!]!
+  metas: [MangaMetaType!]!
+}
+
 input DeleteSourceMetaInput {
   clientMutationId: String
   key: String!
@@ -391,6 +499,23 @@ type DeleteSourceMetaPayload {
   clientMutationId: String
   meta: SourceMetaType
   source: SourceType
+}
+
+input DeleteSourceMetasInput {
+  clientMutationId: String
+  items: [DeleteSourceMetasItemInput!]!
+}
+
+input DeleteSourceMetasItemInput {
+  keys: [String!]
+  prefixes: [String!]
+  sourceIds: [LongString!]!
+}
+
+type DeleteSourceMetasPayload {
+  clientMutationId: String
+  metas: [SourceMetaType!]!
+  sources: [SourceType!]!
 }
 
 input DequeueChapterDownloadInput {
@@ -514,6 +639,9 @@ enum DownloadUpdateType {
   POSITION
 }
 
+"""An ISO-8601 encoded duration string"""
+scalar Duration
+
 interface Edge {
   """A cursor for use in pagination."""
   cursor: Cursor!
@@ -527,7 +655,8 @@ type EditTextPreference {
   default: String
   dialogMessage: String
   dialogTitle: String
-  key: String!
+  enabled: Boolean!
+  key: String
   summary: String
   text: String
   title: String
@@ -629,12 +758,14 @@ type ExtensionType {
 input FetchChapterPagesInput {
   chapterId: Int!
   clientMutationId: String
+  format: String
 }
 
 type FetchChapterPagesPayload {
   chapter: ChapterType!
   clientMutationId: String
   pages: [String!]!
+  syncConflict: SyncConflictInfoType
 }
 
 input FetchChaptersInput {
@@ -709,24 +840,6 @@ input FilterChangeInput {
   triState: TriState
 }
 
-input FloatFilterInput {
-  distinctFrom: Float
-  distinctFromAll: [Float!]
-  distinctFromAny: [Float!]
-  equalTo: Float
-  greaterThan: Float
-  greaterThanOrEqualTo: Float
-  in: [Float!]
-  isNull: Boolean
-  lessThan: Float
-  lessThanOrEqualTo: Float
-  notDistinctFrom: Float
-  notEqualTo: Float
-  notEqualToAll: [Float!]
-  notEqualToAny: [Float!]
-  notIn: [Float!]
-}
-
 type GlobalMetaNodeList implements NodeList {
   edges: [MetaEdge!]!
   nodes: [GlobalMetaType!]!
@@ -787,19 +900,83 @@ input IntFilterInput {
   notIn: [Int!]
 }
 
+enum KoreaderSyncChecksumMethod {
+  BINARY
+  FILENAME
+}
+
+enum KoreaderSyncConflictStrategy {
+  PROMPT
+  KEEP_LOCAL
+  KEEP_REMOTE
+  DISABLED
+}
+
+enum KoreaderSyncLegacyStrategy {
+  PROMPT
+  SILENT
+  SEND
+  RECEIVE
+  DISABLED
+}
+
+type KoSyncConnectPayload {
+  clientMutationId: String
+  message: String
+  status: KoSyncStatusPayload!
+}
+
+type KoSyncStatusPayload {
+  isLoggedIn: Boolean!
+  serverAddress: String
+  username: String
+}
+
 type LastUpdateTimestampPayload {
   timestamp: LongString!
+}
+
+type LibraryUpdateStatus {
+  categoryUpdates: [CategoryUpdateType!]!
+  jobsInfo: UpdaterJobsInfoType!
+  mangaUpdates: [MangaUpdateType!]!
+}
+
+input LibraryUpdateStatusChangedInput {
+  """
+  Sets a max number of updates that can be contained in a updater update
+  message.Everything above this limit will be omitted and the "updateStatus"
+  should be re-fetched via the corresponding query. Due to the graphql
+  subscription execution strategy not supporting batching for data loaders, the
+  data loaders run into the n+1 problem, which can cause the server to get
+  unresponsive until the status update has been handled. This is an issue e.g.
+  when starting an update.
+  """
+  maxUpdates: Int
 }
 
 type ListPreference {
   currentValue: String
   default: String
+  enabled: Boolean!
   entries: [String!]!
   entryValues: [String!]!
-  key: String!
+  key: String
   summary: String
   title: String
   visible: Boolean!
+}
+
+input LoginInput {
+  clientMutationId: String
+  password: String!
+  username: String!
+}
+
+type LoginPayload {
+  accessToken: String!
+  clientMutationId: String
+  refreshToken: String!
 }
 
 input LoginTrackerCredentialsInput {
@@ -825,6 +1002,15 @@ type LoginTrackerOAuthPayload {
   clientMutationId: String
   isLoggedIn: Boolean!
   tracker: TrackerType!
+}
+
+input LogoutKoSyncAccountInput {
+  clientMutationId: String
+}
+
+type LogoutKoSyncAccountPayload {
+  clientMutationId: String
+  status: KoSyncStatusPayload!
 }
 
 input LogoutTrackerInput {
@@ -905,6 +1091,14 @@ input MangaFilterInput {
   thumbnailUrl: StringFilterInput
   title: StringFilterInput
   url: StringFilterInput
+}
+
+enum MangaJobStatus {
+  PENDING
+  RUNNING
+  COMPLETE
+  FAILED
+  SKIPPED
 }
 
 type MangaMetaType implements MetaType {
@@ -994,6 +1188,7 @@ type MangaType {
   downloadCount: Int!
   firstUnreadChapter: ChapterType
   hasDuplicateChapters: Boolean!
+  highestNumberedChapter: ChapterType
   lastReadChapter: ChapterType
   latestFetchedChapter: ChapterType
   latestReadChapter: ChapterType
@@ -1002,6 +1197,11 @@ type MangaType {
   source: SourceType
   trackRecords: TrackRecordNodeList!
   unreadCount: Int!
+}
+
+type MangaUpdateType {
+  status: MangaJobStatus!
+  manga: MangaType!
 }
 
 input MetaConditionInput {
@@ -1020,6 +1220,11 @@ input MetaFilterInput {
   not: MetaFilterInput
   or: [MetaFilterInput!]
   value: StringFilterInput
+}
+
+input MetaInput {
+  key: String!
+  value: String!
 }
 
 enum MetaOrderBy {
@@ -1042,9 +1247,10 @@ type MultiSelectListPreference {
   default: [String!]
   dialogMessage: String
   dialogTitle: String
+  enabled: Boolean!
   entries: [String!]!
   entryValues: [String!]!
-  key: String!
+  key: String
   summary: String
   title: String
   visible: Boolean!
@@ -1056,16 +1262,20 @@ type Mutation {
   createCategory(input: CreateCategoryInput!): CreateCategoryPayload
   deleteCategory(input: DeleteCategoryInput!): DeleteCategoryPayload
   deleteCategoryMeta(input: DeleteCategoryMetaInput!): DeleteCategoryMetaPayload
+  deleteCategoryMetas(input: DeleteCategoryMetasInput!): DeleteCategoryMetasPayload
   setCategoryMeta(input: SetCategoryMetaInput!): SetCategoryMetaPayload
+  setCategoryMetas(input: SetCategoryMetasInput!): SetCategoryMetasPayload
   updateCategories(input: UpdateCategoriesInput!): UpdateCategoriesPayload
   updateCategory(input: UpdateCategoryInput!): UpdateCategoryPayload
   updateCategoryOrder(input: UpdateCategoryOrderInput!): UpdateCategoryOrderPayload
   updateMangaCategories(input: UpdateMangaCategoriesInput!): UpdateMangaCategoriesPayload
   updateMangasCategories(input: UpdateMangasCategoriesInput!): UpdateMangasCategoriesPayload
   deleteChapterMeta(input: DeleteChapterMetaInput!): DeleteChapterMetaPayload
+  deleteChapterMetas(input: DeleteChapterMetasInput!): DeleteChapterMetasPayload
   fetchChapterPages(input: FetchChapterPagesInput!): FetchChapterPagesPayload
   fetchChapters(input: FetchChaptersInput!): FetchChaptersPayload
   setChapterMeta(input: SetChapterMetaInput!): SetChapterMetaPayload
+  setChapterMetas(input: SetChapterMetasInput!): SetChapterMetasPayload
   updateChapter(input: UpdateChapterInput!): UpdateChapterPayload
   updateChapters(input: UpdateChaptersInput!): UpdateChaptersPayload
   clearDownloader(input: ClearDownloaderInput!): ClearDownloaderPayload
@@ -1085,18 +1295,28 @@ type Mutation {
   clearCachedImages(input: ClearCachedImagesInput!): ClearCachedImagesPayload!
   resetWebUIUpdateStatus: WebUIUpdateStatus
   updateWebUI(input: WebUIUpdateInput!): WebUIUpdatePayload
+  connectKoSyncAccount(input: ConnectKoSyncAccountInput!): KoSyncConnectPayload!
+  logoutKoSyncAccount(input: LogoutKoSyncAccountInput!): LogoutKoSyncAccountPayload!
+  pullKoSyncProgress(input: PullKoSyncProgressInput!): PullKoSyncProgressPayload
+  pushKoSyncProgress(input: PushKoSyncProgressInput!): PushKoSyncProgressPayload
   deleteMangaMeta(input: DeleteMangaMetaInput!): DeleteMangaMetaPayload
+  deleteMangaMetas(input: DeleteMangaMetasInput!): DeleteMangaMetasPayload
   fetchManga(input: FetchMangaInput!): FetchMangaPayload
   setMangaMeta(input: SetMangaMetaInput!): SetMangaMetaPayload
+  setMangaMetas(input: SetMangaMetasInput!): SetMangaMetasPayload
   updateManga(input: UpdateMangaInput!): UpdateMangaPayload
   updateMangas(input: UpdateMangasInput!): UpdateMangasPayload
   deleteGlobalMeta(input: DeleteGlobalMetaInput!): DeleteGlobalMetaPayload
+  deleteGlobalMetas(input: DeleteGlobalMetasInput!): DeleteGlobalMetasPayload
   setGlobalMeta(input: SetGlobalMetaInput!): SetGlobalMetaPayload
+  setGlobalMetas(input: SetGlobalMetasInput!): SetGlobalMetasPayload
   resetSettings(input: ResetSettingsInput!): ResetSettingsPayload!
   setSettings(input: SetSettingsInput!): SetSettingsPayload!
   deleteSourceMeta(input: DeleteSourceMetaInput!): DeleteSourceMetaPayload
+  deleteSourceMetas(input: DeleteSourceMetasInput!): DeleteSourceMetasPayload
   fetchSourceManga(input: FetchSourceMangaInput!): FetchSourceMangaPayload
   setSourceMeta(input: SetSourceMetaInput!): SetSourceMetaPayload
+  setSourceMetas(input: SetSourceMetasInput!): SetSourceMetasPayload
   updateSourcePreference(input: UpdateSourcePreferenceInput!): UpdateSourcePreferencePayload
   bindTrack(input: BindTrackInput!): BindTrackPayload!
   fetchTrack(input: FetchTrackInput!): FetchTrackPayload!
@@ -1107,8 +1327,11 @@ type Mutation {
   unbindTrack(input: UnbindTrackInput!): UnbindTrackPayload!
   updateTrack(input: UpdateTrackInput!): UpdateTrackPayload!
   updateCategoryManga(input: UpdateCategoryMangaInput!): UpdateCategoryMangaPayload
+  updateLibrary(input: UpdateLibraryInput!): UpdateLibraryPayload
   updateLibraryManga(input: UpdateLibraryMangaInput!): UpdateLibraryMangaPayload
   updateStop(input: UpdateStopInput!): UpdateStopPayload!
+  login(input: LoginInput!): LoginPayload!
+  refreshToken(input: RefreshTokenInput!): RefreshTokenPayload!
 }
 
 union Node = CategoryMetaType | CategoryType | ChapterMetaType | ChapterType | DownloadType | DownloadUpdate | ExtensionType | GlobalMetaType | MangaMetaType | MangaType | PartialSettingsType | SettingsType | SourceMetaType | SourceType | TrackRecordType | TrackerType
@@ -1143,7 +1366,27 @@ type PageInfo {
   startCursor: Cursor
 }
 
+input PartialBackupFlagsInput {
+  includeCategories: Boolean
+  includeChapters: Boolean
+  includeClientData: Boolean
+  includeHistory: Boolean
+  includeManga: Boolean
+  includeServerSettings: Boolean
+  includeTracking: Boolean
+}
+
 type PartialSettingsType implements Settings {
+  authMode: AuthMode
+  authPassword: String
+  authUsername: String
+  autoBackupIncludeCategories: Boolean
+  autoBackupIncludeChapters: Boolean
+  autoBackupIncludeClientData: Boolean
+  autoBackupIncludeHistory: Boolean
+  autoBackupIncludeManga: Boolean
+  autoBackupIncludeServerSettings: Boolean
+  autoBackupIncludeTracking: Boolean
   autoDownloadAheadLimit: Int @deprecated(reason: "Replaced with autoDownloadNewChaptersLimit, replace with autoDownloadNewChaptersLimit")
   autoDownloadIgnoreReUploads: Boolean
   autoDownloadNewChapters: Boolean
@@ -1152,11 +1395,16 @@ type PartialSettingsType implements Settings {
   backupPath: String
   backupTTL: Int
   backupTime: String
-  basicAuthEnabled: Boolean
-  basicAuthPassword: String
-  basicAuthUsername: String
+  basicAuthEnabled: Boolean @deprecated(reason: "Removed - prefer authMode, replace with authMode")
+  basicAuthPassword: String @deprecated(reason: "Removed - prefer authPassword, replace with authPassword")
+  basicAuthUsername: String @deprecated(reason: "Removed - prefer authUsername, replace with authUsername")
+  databasePassword: String
+  databaseType: DatabaseType
+  databaseUrl: String
+  databaseUsername: String
   debugLogsEnabled: Boolean
   downloadAsCbz: Boolean
+  downloadConversions: [SettingsDownloadConversionType!]
   downloadsPath: String
   electronPath: String
   excludeCompleted: Boolean
@@ -1174,12 +1422,33 @@ type PartialSettingsType implements Settings {
   gqlDebugLogsEnabled: Boolean @deprecated(reason: "Removed - does not do anything")
   initialOpenInBrowserEnabled: Boolean
   ip: String
+  jwtAudience: String
+  jwtRefreshExpiry: Duration
+  jwtTokenExpiry: Duration
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod
+  koreaderSyncDeviceId: String @deprecated(reason: "Moved to preference store. Is supposed to be random and gets auto generated, replace with MOVE TO PREFERENCES")
+  koreaderSyncPercentageTolerance: Float
+  koreaderSyncServerUrl: String @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
+  koreaderSyncStrategy: KoreaderSyncLegacyStrategy @deprecated(reason: "Replaced with koreaderSyncStrategyForward and koreaderSyncStrategyBackward, replace with koreaderSyncStrategyForward, koreaderSyncStrategyBackward")
+  koreaderSyncStrategyBackward: KoreaderSyncConflictStrategy
+  koreaderSyncStrategyForward: KoreaderSyncConflictStrategy
+  koreaderSyncUserkey: String @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
+  koreaderSyncUsername: String @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
   localSourcePath: String
   maxLogFileSize: String
   maxLogFiles: Int
   maxLogFolderSize: String
   maxSourcesInParallel: Int
+  opdsCbzMimetype: CbzMediaType
+  opdsChapterSortOrder: SortOrder
+  opdsEnablePageReadProgress: Boolean
+  opdsItemsPerPage: Int
+  opdsMarkAsReadOnDownload: Boolean
+  opdsShowOnlyDownloadedChapters: Boolean
+  opdsShowOnlyUnreadChapters: Boolean
+  opdsUseBinaryFileSizes: Boolean
   port: Int
+  serveConversions: [SettingsDownloadConversionType!]
   socksProxyEnabled: Boolean
   socksProxyHost: String
   socksProxyPassword: String
@@ -1188,6 +1457,7 @@ type PartialSettingsType implements Settings {
   socksProxyVersion: Int
   systemTrayEnabled: Boolean
   updateMangas: Boolean
+  useHikariConnectionPool: Boolean
   webUIChannel: WebUIChannel
   webUIFlavor: WebUIFlavor
   webUIInterface: WebUIInterface
@@ -1195,6 +1465,16 @@ type PartialSettingsType implements Settings {
 }
 
 input PartialSettingsTypeInput {
+  authMode: AuthMode
+  authPassword: String
+  authUsername: String
+  autoBackupIncludeCategories: Boolean
+  autoBackupIncludeChapters: Boolean
+  autoBackupIncludeClientData: Boolean
+  autoBackupIncludeHistory: Boolean
+  autoBackupIncludeManga: Boolean
+  autoBackupIncludeServerSettings: Boolean
+  autoBackupIncludeTracking: Boolean
   autoDownloadIgnoreReUploads: Boolean
   autoDownloadNewChapters: Boolean
   autoDownloadNewChaptersLimit: Int
@@ -1202,11 +1482,13 @@ input PartialSettingsTypeInput {
   backupPath: String
   backupTTL: Int
   backupTime: String
-  basicAuthEnabled: Boolean
-  basicAuthPassword: String
-  basicAuthUsername: String
+  databasePassword: String
+  databaseType: DatabaseType
+  databaseUrl: String
+  databaseUsername: String
   debugLogsEnabled: Boolean
   downloadAsCbz: Boolean
+  downloadConversions: [SettingsDownloadConversionTypeInput!]
   downloadsPath: String
   electronPath: String
   excludeCompleted: Boolean
@@ -1223,12 +1505,28 @@ input PartialSettingsTypeInput {
   globalUpdateInterval: Float
   initialOpenInBrowserEnabled: Boolean
   ip: String
+  jwtAudience: String
+  jwtRefreshExpiry: Duration
+  jwtTokenExpiry: Duration
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod
+  koreaderSyncPercentageTolerance: Float
+  koreaderSyncStrategyBackward: KoreaderSyncConflictStrategy
+  koreaderSyncStrategyForward: KoreaderSyncConflictStrategy
   localSourcePath: String
   maxLogFileSize: String
   maxLogFiles: Int
   maxLogFolderSize: String
   maxSourcesInParallel: Int
+  opdsCbzMimetype: CbzMediaType
+  opdsChapterSortOrder: SortOrder
+  opdsEnablePageReadProgress: Boolean
+  opdsItemsPerPage: Int
+  opdsMarkAsReadOnDownload: Boolean
+  opdsShowOnlyDownloadedChapters: Boolean
+  opdsShowOnlyUnreadChapters: Boolean
+  opdsUseBinaryFileSizes: Boolean
   port: Int
+  serveConversions: [SettingsDownloadConversionTypeInput!]
   socksProxyEnabled: Boolean
   socksProxyHost: String
   socksProxyPassword: String
@@ -1237,6 +1535,7 @@ input PartialSettingsTypeInput {
   socksProxyVersion: Int
   systemTrayEnabled: Boolean
   updateMangas: Boolean
+  useHikariConnectionPool: Boolean
   webUIChannel: WebUIChannel
   webUIFlavor: WebUIFlavor
   webUIInterface: WebUIInterface
@@ -1244,6 +1543,28 @@ input PartialSettingsTypeInput {
 }
 
 union Preference = CheckBoxPreference | EditTextPreference | ListPreference | MultiSelectListPreference | SwitchPreference
+
+input PullKoSyncProgressInput {
+  chapterId: Int!
+  clientMutationId: String
+}
+
+type PullKoSyncProgressPayload {
+  chapter: ChapterType
+  clientMutationId: String
+  syncConflict: SyncConflictInfoType
+}
+
+input PushKoSyncProgressInput {
+  chapterId: Int!
+  clientMutationId: String
+}
+
+type PushKoSyncProgressPayload {
+  chapter: ChapterType
+  clientMutationId: String
+  success: Boolean!
+}
 
 type Query {
   restoreStatus(id: String!): BackupRestoreStatus
@@ -1260,6 +1581,7 @@ type Query {
   checkForServerUpdates: [CheckForServerUpdatesPayload!]!
   checkForWebUIUpdate: WebUIUpdateCheck!
   getWebUIUpdateStatus: WebUIUpdateStatus!
+  koSyncStatus: KoSyncStatusPayload!
   manga(id: Int!): MangaType!
   mangas(condition: MangaConditionInput, filter: MangaFilterInput, orderBy: MangaOrderBy, orderByType: SortOrder, order: [MangaOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): MangaNodeList!
   meta(key: String!): GlobalMetaType!
@@ -1273,7 +1595,18 @@ type Query {
   tracker(id: Int!): TrackerType!
   trackers(condition: TrackerConditionInput, orderBy: TrackerOrderBy, orderByType: SortOrder, order: [TrackerOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): TrackerNodeList!
   lastUpdateTimestamp: LastUpdateTimestampPayload!
-  updateStatus: UpdateStatus!
+  libraryUpdateStatus: LibraryUpdateStatus!
+  updateStatus: UpdateStatus! @deprecated(reason: "Replaced with libraryUpdateStatus, replace with libraryUpdateStatus")
+}
+
+input RefreshTokenInput {
+  clientMutationId: String
+  refreshToken: String!
+}
+
+type RefreshTokenPayload {
+  accessToken: String!
+  clientMutationId: String
 }
 
 input ReorderChapterDownloadInput {
@@ -1299,6 +1632,7 @@ type ResetSettingsPayload {
 input RestoreBackupInput {
   backup: Upload!
   clientMutationId: String
+  flags: PartialBackupFlagsInput
 }
 
 type RestoreBackupPayload {
@@ -1336,6 +1670,22 @@ type SetCategoryMetaPayload {
   meta: CategoryMetaType!
 }
 
+input SetCategoryMetasInput {
+  clientMutationId: String
+  items: [SetCategoryMetasItemInput!]!
+}
+
+input SetCategoryMetasItemInput {
+  categoryIds: [Int!]!
+  metas: [MetaInput!]!
+}
+
+type SetCategoryMetasPayload {
+  categories: [CategoryType!]!
+  clientMutationId: String
+  metas: [CategoryMetaType!]!
+}
+
 input SetChapterMetaInput {
   clientMutationId: String
   meta: ChapterMetaTypeInput!
@@ -1344,6 +1694,22 @@ input SetChapterMetaInput {
 type SetChapterMetaPayload {
   clientMutationId: String
   meta: ChapterMetaType!
+}
+
+input SetChapterMetasInput {
+  clientMutationId: String
+  items: [SetChapterMetasItemInput!]!
+}
+
+input SetChapterMetasItemInput {
+  chapterIds: [Int!]!
+  metas: [MetaInput!]!
+}
+
+type SetChapterMetasPayload {
+  chapters: [ChapterType!]!
+  clientMutationId: String
+  metas: [ChapterMetaType!]!
 }
 
 input SetGlobalMetaInput {
@@ -1356,6 +1722,16 @@ type SetGlobalMetaPayload {
   meta: GlobalMetaType!
 }
 
+input SetGlobalMetasInput {
+  clientMutationId: String
+  metas: [MetaInput!]!
+}
+
+type SetGlobalMetasPayload {
+  clientMutationId: String
+  metas: [GlobalMetaType!]!
+}
+
 input SetMangaMetaInput {
   clientMutationId: String
   meta: MangaMetaTypeInput!
@@ -1364,6 +1740,22 @@ input SetMangaMetaInput {
 type SetMangaMetaPayload {
   clientMutationId: String
   meta: MangaMetaType!
+}
+
+input SetMangaMetasInput {
+  clientMutationId: String
+  items: [SetMangaMetasItemInput!]!
+}
+
+input SetMangaMetasItemInput {
+  mangaIds: [Int!]!
+  metas: [MetaInput!]!
+}
+
+type SetMangaMetasPayload {
+  clientMutationId: String
+  mangas: [MangaType!]!
+  metas: [MangaMetaType!]!
 }
 
 input SetSettingsInput {
@@ -1386,7 +1778,33 @@ type SetSourceMetaPayload {
   meta: SourceMetaType!
 }
 
+input SetSourceMetasInput {
+  clientMutationId: String
+  items: [SetSourceMetasItemInput!]!
+}
+
+input SetSourceMetasItemInput {
+  metas: [MetaInput!]!
+  sourceIds: [LongString!]!
+}
+
+type SetSourceMetasPayload {
+  clientMutationId: String
+  metas: [SourceMetaType!]!
+  sources: [SourceType!]!
+}
+
 interface Settings {
+  authMode: AuthMode
+  authPassword: String
+  authUsername: String
+  autoBackupIncludeCategories: Boolean
+  autoBackupIncludeChapters: Boolean
+  autoBackupIncludeClientData: Boolean
+  autoBackupIncludeHistory: Boolean
+  autoBackupIncludeManga: Boolean
+  autoBackupIncludeServerSettings: Boolean
+  autoBackupIncludeTracking: Boolean
   autoDownloadAheadLimit: Int @deprecated(reason: "Replaced with autoDownloadNewChaptersLimit, replace with autoDownloadNewChaptersLimit")
   autoDownloadIgnoreReUploads: Boolean
   autoDownloadNewChapters: Boolean
@@ -1395,11 +1813,16 @@ interface Settings {
   backupPath: String
   backupTTL: Int
   backupTime: String
-  basicAuthEnabled: Boolean
-  basicAuthPassword: String
-  basicAuthUsername: String
+  basicAuthEnabled: Boolean @deprecated(reason: "Removed - prefer authMode, replace with authMode")
+  basicAuthPassword: String @deprecated(reason: "Removed - prefer authPassword, replace with authPassword")
+  basicAuthUsername: String @deprecated(reason: "Removed - prefer authUsername, replace with authUsername")
+  databasePassword: String
+  databaseType: DatabaseType
+  databaseUrl: String
+  databaseUsername: String
   debugLogsEnabled: Boolean
   downloadAsCbz: Boolean
+  downloadConversions: [SettingsDownloadConversion!]
   downloadsPath: String
   electronPath: String
   excludeCompleted: Boolean
@@ -1417,12 +1840,33 @@ interface Settings {
   gqlDebugLogsEnabled: Boolean @deprecated(reason: "Removed - does not do anything")
   initialOpenInBrowserEnabled: Boolean
   ip: String
+  jwtAudience: String
+  jwtRefreshExpiry: Duration
+  jwtTokenExpiry: Duration
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod
+  koreaderSyncDeviceId: String @deprecated(reason: "Moved to preference store. Is supposed to be random and gets auto generated, replace with MOVE TO PREFERENCES")
+  koreaderSyncPercentageTolerance: Float
+  koreaderSyncServerUrl: String @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
+  koreaderSyncStrategy: KoreaderSyncLegacyStrategy @deprecated(reason: "Replaced with koreaderSyncStrategyForward and koreaderSyncStrategyBackward, replace with koreaderSyncStrategyForward, koreaderSyncStrategyBackward")
+  koreaderSyncStrategyBackward: KoreaderSyncConflictStrategy
+  koreaderSyncStrategyForward: KoreaderSyncConflictStrategy
+  koreaderSyncUserkey: String @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
+  koreaderSyncUsername: String @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
   localSourcePath: String
   maxLogFileSize: String
   maxLogFiles: Int
   maxLogFolderSize: String
   maxSourcesInParallel: Int
+  opdsCbzMimetype: CbzMediaType
+  opdsChapterSortOrder: SortOrder
+  opdsEnablePageReadProgress: Boolean
+  opdsItemsPerPage: Int
+  opdsMarkAsReadOnDownload: Boolean
+  opdsShowOnlyDownloadedChapters: Boolean
+  opdsShowOnlyUnreadChapters: Boolean
+  opdsUseBinaryFileSizes: Boolean
   port: Int
+  serveConversions: [SettingsDownloadConversion!]
   socksProxyEnabled: Boolean
   socksProxyHost: String
   socksProxyPassword: String
@@ -1431,26 +1875,84 @@ interface Settings {
   socksProxyVersion: Int
   systemTrayEnabled: Boolean
   updateMangas: Boolean
+  useHikariConnectionPool: Boolean
   webUIChannel: WebUIChannel
   webUIFlavor: WebUIFlavor
   webUIInterface: WebUIInterface
   webUIUpdateCheckInterval: Float
 }
 
+interface SettingsDownloadConversion {
+  callTimeout: Duration
+  compressionLevel: Float
+  connectTimeout: Duration
+  headers: [SettingsDownloadConversionHeader!]
+  mimeType: String!
+  target: String!
+}
+
+interface SettingsDownloadConversionHeader {
+  name: String!
+  value: String!
+}
+
+type SettingsDownloadConversionHeaderType implements SettingsDownloadConversionHeader {
+  name: String!
+  value: String!
+}
+
+input SettingsDownloadConversionHeaderTypeInput {
+  name: String!
+  value: String!
+}
+
+type SettingsDownloadConversionType implements SettingsDownloadConversion {
+  callTimeout: Duration
+  compressionLevel: Float
+  connectTimeout: Duration
+  headers: [SettingsDownloadConversionHeaderType!]
+  mimeType: String!
+  target: String!
+}
+
+input SettingsDownloadConversionTypeInput {
+  callTimeout: Duration
+  compressionLevel: Float
+  connectTimeout: Duration
+  headers: [SettingsDownloadConversionHeaderTypeInput!]
+  mimeType: String!
+  target: String!
+}
+
 type SettingsType implements Settings {
+  authMode: AuthMode!
+  authPassword: String!
+  authUsername: String!
+  autoBackupIncludeCategories: Boolean!
+  autoBackupIncludeChapters: Boolean!
+  autoBackupIncludeClientData: Boolean!
+  autoBackupIncludeHistory: Boolean!
+  autoBackupIncludeManga: Boolean!
+  autoBackupIncludeServerSettings: Boolean!
+  autoBackupIncludeTracking: Boolean!
   autoDownloadAheadLimit: Int! @deprecated(reason: "Replaced with autoDownloadNewChaptersLimit, replace with autoDownloadNewChaptersLimit")
-  autoDownloadIgnoreReUploads: Boolean
+  autoDownloadIgnoreReUploads: Boolean!
   autoDownloadNewChapters: Boolean!
   autoDownloadNewChaptersLimit: Int!
   backupInterval: Int!
   backupPath: String!
   backupTTL: Int!
   backupTime: String!
-  basicAuthEnabled: Boolean!
-  basicAuthPassword: String!
-  basicAuthUsername: String!
+  basicAuthEnabled: Boolean! @deprecated(reason: "Removed - prefer authMode, replace with authMode")
+  basicAuthPassword: String! @deprecated(reason: "Removed - prefer authPassword, replace with authPassword")
+  basicAuthUsername: String! @deprecated(reason: "Removed - prefer authUsername, replace with authUsername")
+  databasePassword: String!
+  databaseType: DatabaseType!
+  databaseUrl: String!
+  databaseUsername: String!
   debugLogsEnabled: Boolean!
   downloadAsCbz: Boolean!
+  downloadConversions: [SettingsDownloadConversionType!]!
   downloadsPath: String!
   electronPath: String!
   excludeCompleted: Boolean!
@@ -1468,12 +1970,33 @@ type SettingsType implements Settings {
   gqlDebugLogsEnabled: Boolean! @deprecated(reason: "Removed - does not do anything")
   initialOpenInBrowserEnabled: Boolean!
   ip: String!
+  jwtAudience: String!
+  jwtRefreshExpiry: Duration!
+  jwtTokenExpiry: Duration!
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod!
+  koreaderSyncDeviceId: String! @deprecated(reason: "Moved to preference store. Is supposed to be random and gets auto generated, replace with MOVE TO PREFERENCES")
+  koreaderSyncPercentageTolerance: Float!
+  koreaderSyncServerUrl: String! @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
+  koreaderSyncStrategy: KoreaderSyncLegacyStrategy! @deprecated(reason: "Replaced with koreaderSyncStrategyForward and koreaderSyncStrategyBackward, replace with koreaderSyncStrategyForward, koreaderSyncStrategyBackward")
+  koreaderSyncStrategyBackward: KoreaderSyncConflictStrategy!
+  koreaderSyncStrategyForward: KoreaderSyncConflictStrategy!
+  koreaderSyncUserkey: String! @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
+  koreaderSyncUsername: String! @deprecated(reason: "Moved to preference store. User is supposed to use a login/logout mutation, replace with MOVE TO PREFERENCES")
   localSourcePath: String!
   maxLogFileSize: String!
   maxLogFiles: Int!
   maxLogFolderSize: String!
   maxSourcesInParallel: Int!
+  opdsCbzMimetype: CbzMediaType!
+  opdsChapterSortOrder: SortOrder!
+  opdsEnablePageReadProgress: Boolean!
+  opdsItemsPerPage: Int!
+  opdsMarkAsReadOnDownload: Boolean!
+  opdsShowOnlyDownloadedChapters: Boolean!
+  opdsShowOnlyUnreadChapters: Boolean!
+  opdsUseBinaryFileSizes: Boolean!
   port: Int!
+  serveConversions: [SettingsDownloadConversionType!]!
   socksProxyEnabled: Boolean!
   socksProxyHost: String!
   socksProxyPassword: String!
@@ -1482,6 +2005,7 @@ type SettingsType implements Settings {
   socksProxyVersion: Int!
   systemTrayEnabled: Boolean!
   updateMangas: Boolean!
+  useHikariConnectionPool: Boolean!
   webUIChannel: WebUIChannel!
   webUIFlavor: WebUIFlavor!
   webUIInterface: WebUIInterface!
@@ -1576,6 +2100,7 @@ input SourcePreferenceChangeInput {
 }
 
 type SourceType {
+  baseUrl: String
   displayName: String!
   iconUrl: String!
   id: LongString!
@@ -1686,19 +2211,26 @@ input StringFilterInput {
 }
 
 type Subscription {
-  downloadChanged: DownloadStatus! @deprecated(reason: "Replaced width downloadStatusChanged, replace with downloadStatusChanged(input)")
+  downloadChanged: DownloadStatus! @deprecated(reason: "Replaced with downloadStatusChanged, replace with downloadStatusChanged(input)")
   downloadStatusChanged(input: DownloadChangedInput!): DownloadUpdates!
   webUIUpdateStatusChange: WebUIUpdateStatus!
-  updateStatusChanged: UpdateStatus!
+  libraryUpdateStatusChanged(input: LibraryUpdateStatusChangedInput!): UpdaterUpdates!
+  updateStatusChanged: UpdateStatus! @deprecated(reason: "Replaced with updates, replace with updates(input)")
 }
 
 type SwitchPreference {
   currentValue: Boolean
   default: Boolean!
-  key: String!
+  enabled: Boolean!
+  key: String
   summary: String
-  title: String!
+  title: String
   visible: Boolean!
+}
+
+type SyncConflictInfoType {
+  deviceName: String!
+  remotePage: Int!
 }
 
 type TextFilter {
@@ -1742,7 +2274,9 @@ type TrackerType {
   id: Int!
   isLoggedIn: Boolean!
   name: String!
-  supportsTrackDeletion: Boolean
+  supportsPrivateTracking: Boolean!
+  supportsReadingDates: Boolean!
+  supportsTrackDeletion: Boolean!
   isTokenExpired: Boolean!
   scores: [String!]!
   statuses: [TrackStatusType!]!
@@ -1765,6 +2299,7 @@ input TrackRecordConditionInput {
   lastChapterRead: Float
   libraryId: LongString
   mangaId: Int
+  private: Boolean
   remoteId: LongString
   remoteUrl: String
   score: Float
@@ -1789,6 +2324,7 @@ input TrackRecordFilterInput {
   mangaId: IntFilterInput
   not: TrackRecordFilterInput
   or: [TrackRecordFilterInput!]
+  private: BooleanFilterInput
   remoteId: LongFilterInput
   remoteUrl: StringFilterInput
   score: DoubleFilterInput
@@ -1817,6 +2353,7 @@ enum TrackRecordOrderBy {
   SCORE
   START_DATE
   FINISH_DATE
+  PRIVATE
 }
 
 input TrackRecordOrderInput {
@@ -1830,6 +2367,7 @@ type TrackRecordType {
   lastChapterRead: Float!
   libraryId: LongString
   mangaId: Int!
+  private: Boolean!
   remoteId: LongString!
   remoteUrl: String!
   score: Float!
@@ -1845,16 +2383,24 @@ type TrackRecordType {
 
 type TrackSearchType {
   coverUrl: String!
+  finishedReadingDate: LongString!
   id: Int!
+  lastChapterRead: Float!
+  libraryId: LongString
+  private: Boolean!
   publishingStatus: String!
   publishingType: String!
   remoteId: LongString!
+  score: Float!
   startDate: String!
+  startedReadingDate: LongString!
+  status: Int!
   summary: String!
   title: String!
   totalChapters: Int!
   trackerId: Int!
   trackingUrl: String!
+  displayScore: String!
   tracker: TrackerType!
 }
 
@@ -1995,6 +2541,11 @@ type UpdateExtensionsPayload {
   extensions: [ExtensionType!]!
 }
 
+input UpdateLibraryInput {
+  categories: [Int!]
+  clientMutationId: String
+}
+
 input UpdateLibraryMangaInput {
   clientMutationId: String
 }
@@ -2002,6 +2553,11 @@ input UpdateLibraryMangaInput {
 type UpdateLibraryMangaPayload {
   clientMutationId: String
   updateStatus: UpdateStatus!
+}
+
+type UpdateLibraryPayload {
+  clientMutationId: String
+  updateStatus: LibraryUpdateStatus!
 }
 
 input UpdateMangaCategoriesInput {
@@ -2058,6 +2614,32 @@ type UpdateMangasPayload {
   mangas: [MangaType!]!
 }
 
+type UpdaterJobsInfoType {
+  finishedJobs: Int!
+  isRunning: Boolean!
+  skippedCategoriesCount: Int!
+  skippedMangasCount: Int!
+  totalJobs: Int!
+}
+
+type UpdaterUpdates {
+  categoryUpdates: [CategoryUpdateType!]!
+
+  """
+  The current update status at the time of sending the initial message. Is null for all following messages
+  """
+  initial: LibraryUpdateStatus
+  jobsInfo: UpdaterJobsInfoType!
+  mangaUpdates: [MangaUpdateType!]!
+
+  """
+  Indicates whether updates have been omitted based on the "maxUpdates"
+  subscription variable. In case updates have been omitted, the "updateStatus"
+  query should be re-fetched.
+  """
+  omittedUpdates: Boolean!
+}
+
 input UpdateSourcePreferenceInput {
   change: SourcePreferenceChangeInput!
   clientMutationId: String
@@ -2111,10 +2693,23 @@ enum UpdateStrategy {
 
 input UpdateTrackInput {
   clientMutationId: String
+
+  """
+  This will only work if the tracker of the track record supports reading dates
+  """
   finishDate: LongString
   lastChapterRead: Float
+
+  """
+  This will only work if the tracker of the track record supports private tracking
+  """
+  private: Boolean
   recordId: Int!
   scoreString: String
+
+  """
+  This will only work if the tracker of the track record supports reading dates
+  """
   startDate: LongString
   status: Int
 }
@@ -2163,13 +2758,13 @@ enum WebUIInterface {
 }
 
 type WebUIUpdateCheck {
-  channel: String!
+  channel: WebUIChannel!
   tag: String!
   updateAvailable: Boolean!
 }
 
 type WebUIUpdateInfo {
-  channel: String!
+  channel: WebUIChannel!
   tag: String!
 }
 

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -33,6 +33,57 @@
     "@authTypeBasic": {
         "description": "Radio button text for the Basic Authentication type"
     },
+    "@authTypeSimpleLogin": {
+        "description": "Radio button text for Suwayomi server's simple_login auth mode"
+    },
+    "@authTypeUiLogin": {
+        "description": "Radio button text for Suwayomi server's ui_login (JWT) auth mode, marked as recommended"
+    },
+    "@authReverseProxyHelp": {
+        "description": "Helper text under the login fields explaining how to use Sorayomi with a reverse proxy in front of Suwayomi"
+    },
+    "@authTestConnection": {
+        "description": "Button text for testing the entered credentials against the server"
+    },
+    "@authTestConnectionSuccess": {
+        "description": "Success toast text after Test Connection succeeds"
+    },
+    "@authTestConnectionFailedNetwork": {
+        "description": "Error message when Test Connection cannot reach the server"
+    },
+    "@authTestConnectionFailedAuth": {
+        "description": "Error message when Test Connection reaches the server but credentials are rejected"
+    },
+    "@authTestConnectionFailedMode": {
+        "description": "Error message when Test Connection succeeds at login but the server appears to be in a different auth mode"
+    },
+    "@authTestConnectionFailedShape": {
+        "description": "Error message when the server's response is not the expected shape"
+    },
+    "@authSessionExpired": {
+        "description": "Banner text shown at top of screens when the session has expired and the user must re-authenticate"
+    },
+    "@authReauthenticate": {
+        "description": "Button text on the session-expired banner that opens the re-auth prompt"
+    },
+    "@authInsecureTransportTitle": {
+        "description": "Title of the http:// warning confirmation dialog"
+    },
+    "@authInsecureTransportWarning": {
+        "description": "Warning body shown when the user is about to send credentials over http:// instead of https://"
+    },
+    "@authInsecureTransportContinue": {
+        "description": "Button text to acknowledge the http:// warning and proceed anyway"
+    },
+    "@authLogout": {
+        "description": "Tile title in settings to log out and clear stored credentials"
+    },
+    "@authLogoutConfirm": {
+        "description": "Confirmation dialog text shown when the user taps Log out"
+    },
+    "@authImageUrlLogWarning": {
+        "description": "Additional note in helper text explaining the ui_login image URL token leak risk"
+    },
     "@authTypeNone": {
         "description": "Radio button text for no Authentication"
     },
@@ -949,6 +1000,23 @@
     "appearance": "Appearance",
     "authType": "Authentication Type",
     "authTypeBasic": "Basic Auth",
+    "authTypeSimpleLogin": "Simple Login",
+    "authTypeUiLogin": "UI Login (recommended)",
+    "authReverseProxyHelp": "If you use a reverse proxy in front of Suwayomi (Pangolin, Authelia, Authentik, Cloudflare Access, etc.), configure the proxy to pass requests through and let Suwayomi handle authentication here.",
+    "authTestConnection": "Test connection",
+    "authTestConnectionSuccess": "Connected.",
+    "authTestConnectionFailedNetwork": "Couldn't reach server. Check URL and connectivity.",
+    "authTestConnectionFailedAuth": "Login failed. Check username and password.",
+    "authTestConnectionFailedMode": "Server may not be in the selected auth mode. Check the server's authMode setting.",
+    "authTestConnectionFailedShape": "Server didn't respond as expected. Is your URL pointing at the Suwayomi API?",
+    "authSessionExpired": "Session expired — sign in again.",
+    "authReauthenticate": "Re-authenticate",
+    "authInsecureTransportTitle": "Insecure connection",
+    "authInsecureTransportWarning": "Your server URL uses http:// — your username and password will be sent in cleartext over the network. Use https:// unless you trust the network entirely.",
+    "authInsecureTransportContinue": "I understand, continue",
+    "authLogout": "Log out",
+    "authLogoutConfirm": "Log out and clear stored credentials? You'll need to sign in again to use this server.",
+    "authImageUrlLogWarning": "Note: with UI Login, image URLs include your access token as a query parameter, which can appear in your server's access logs.",
     "authTypeNone": "None",
     "authentication": "Authentication",
     "autoDownload": "Auto-download",

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -60,6 +60,9 @@
     "@authTestConnectionFailedShape": {
         "description": "Error message when the server's response is not the expected shape"
     },
+    "@authTestConnectionFailedTls": {
+        "description": "Error message when the client sends TLS bytes to a plaintext server, or vice versa — typically a wrong scheme (http vs https) or wrong port"
+    },
     "@authSessionExpired": {
         "description": "Banner text shown at top of screens when the session has expired and the user must re-authenticate"
     },
@@ -1002,13 +1005,14 @@
     "authTypeBasic": "Basic Auth",
     "authTypeSimpleLogin": "Simple Login",
     "authTypeUiLogin": "UI Login (recommended)",
-    "authReverseProxyHelp": "If you use a reverse proxy in front of Suwayomi (Pangolin, Authelia, Authentik, Cloudflare Access, etc.), configure the proxy to pass requests through and let Suwayomi handle authentication here.",
+    "authReverseProxyHelp": "If you use a reverse proxy in front of Suwayomi (Pangolin, Authelia, Authentik, Cloudflare Access, etc.), configure the proxy to pass requests through and let Suwayomi handle authentication here. For public hostnames, turn OFF the 'Use Server Port' toggle on the Server screen so requests go to standard 443.",
     "authTestConnection": "Test connection",
     "authTestConnectionSuccess": "Connected.",
     "authTestConnectionFailedNetwork": "Couldn't reach server. Check URL and connectivity.",
     "authTestConnectionFailedAuth": "Login failed. Check username and password.",
     "authTestConnectionFailedMode": "Server may not be in the selected auth mode. Check the server's authMode setting.",
     "authTestConnectionFailedShape": "Server didn't respond as expected. Is your URL pointing at the Suwayomi API?",
+    "authTestConnectionFailedTls": "TLS handshake failed. Common causes: 1) Server is plain HTTP — switch your URL to http://. 2) Public hostname behind a reverse proxy — turn OFF the 'Use Server Port' toggle on the Server screen so requests go to standard 443.",
     "authSessionExpired": "Session expired — sign in again.",
     "authReauthenticate": "Re-authenticate",
     "authInsecureTransportTitle": "Insecure connection",

--- a/lib/src/sorayomi.dart
+++ b/lib/src/sorayomi.dart
@@ -10,6 +10,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import 'features/auth/presentation/reauth_banner.dart';
 import 'features/settings/presentation/appearance/widgets/app_theme_selector/app_theme_selector.dart';
 import 'features/settings/presentation/appearance/widgets/is_true_black/is_true_black_tile.dart';
 import 'features/settings/widgets/app_theme_mode_tile/app_theme_mode_tile.dart';
@@ -32,7 +33,10 @@ class Sorayomi extends ConsumerWidget {
     return GraphQLProvider(
       client: client,
       child: MaterialApp.router(
-        builder: FToastBuilder(),
+        builder: (context, child) {
+          final toastWrapped = FToastBuilder()(context, child);
+          return ReauthBannerHost(child: toastWrapped);
+        },
         onGenerateTitle: (context) => context.l10n.appTitle,
         debugShowCheckedModeBanner: false,
         theme: FlexThemeData.light(

--- a/lib/src/utils/extensions/cache_manager_extensions.dart
+++ b/lib/src/utils/extensions/cache_manager_extensions.dart
@@ -11,6 +11,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../constants/endpoints.dart';
 import '../../constants/enum.dart';
+import '../../features/auth/data/auth_credentials_store.dart';
 import '../../features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../../features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import '../../features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
@@ -22,6 +23,7 @@ extension CacheManagerExtension on CacheManager {
       {bool appendApiToUrl = true}) async {
     final authType = ref.read(authTypeKeyProvider);
     final basicToken = ref.read(credentialsProvider).valueOrNull;
+    final creds = ref.read(authCredentialsStoreProvider).valueOrNull;
     final baseApi = "${Endpoints.baseApi(
       baseUrl: ref.read(serverUrlProvider),
       port: ref.read(serverPortProvider),
@@ -29,11 +31,26 @@ extension CacheManagerExtension on CacheManager {
       appendApiToUrl: appendApiToUrl,
     )}"
         "$url";
-    return await getSingleFile(
-      baseApi,
-      headers: authType == AuthType.basic && basicToken != null
-          ? {"Authorization": basicToken}
-          : null,
-    );
+
+    Map<String, String>? headers;
+    if (authType == AuthType.basic && basicToken != null) {
+      headers = {"Authorization": basicToken};
+    } else if (authType == AuthType.simpleLogin) {
+      headers = creds?.simpleLoginCookieHeader;
+    }
+
+    // For ui_login, append ?token= because cached_network_image can't
+    // reliably forward Authorization headers on web. Use the un-tokened
+    // URL as cacheKey so token rotation doesn't bust the cache.
+    var fetchUrl = baseApi;
+    if (authType == AuthType.uiLogin &&
+        creds?.uiAccessToken != null &&
+        creds!.uiAccessToken!.isNotEmpty) {
+      final sep = fetchUrl.contains('?') ? '&' : '?';
+      fetchUrl =
+          '$fetchUrl${sep}token=${Uri.encodeQueryComponent(creds.uiAccessToken!)}';
+    }
+
+    return await getSingleFile(fetchUrl, key: baseApi, headers: headers);
   }
 }

--- a/lib/src/utils/extensions/cache_manager_extensions.dart
+++ b/lib/src/utils/extensions/cache_manager_extensions.dart
@@ -21,7 +21,7 @@ extension CacheManagerExtension on CacheManager {
   Future<File> getServerFile(WidgetRef ref, String url,
       {bool appendApiToUrl = true}) async {
     final authType = ref.read(authTypeKeyProvider);
-    final basicToken = ref.read(credentialsProvider);
+    final basicToken = ref.read(credentialsProvider).valueOrNull;
     final baseApi = "${Endpoints.baseApi(
       baseUrl: ref.read(serverUrlProvider),
       port: ref.read(serverPortProvider),

--- a/lib/src/widgets/server_image.dart
+++ b/lib/src/widgets/server_image.dart
@@ -15,6 +15,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../constants/app_sizes.dart';
 import '../constants/endpoints.dart';
 import '../constants/enum.dart';
+import '../features/auth/data/auth_credentials_store.dart';
 import '../features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import '../features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
@@ -50,6 +51,7 @@ class ServerImage extends HookConsumerWidget {
     // Providers
     final authType = ref.watch(authTypeKeyProvider);
     final basicToken = ref.watch(credentialsProvider).valueOrNull;
+    final creds = ref.watch(authCredentialsStoreProvider).valueOrNull;
 
     final baseApi = "${Endpoints.baseApi(
       baseUrl: ref.watch(serverUrlProvider),
@@ -59,13 +61,27 @@ class ServerImage extends HookConsumerWidget {
     )}"
         "$imageUrl";
 
-    final Map<String, String>? httpHeaders =
-        (authType == AuthType.basic && basicToken != null)
-            ? ({"Authorization": basicToken})
-            : null;
+    Map<String, String>? httpHeaders;
+    if (authType == AuthType.basic && basicToken != null) {
+      httpHeaders = {"Authorization": basicToken};
+    } else if (authType == AuthType.simpleLogin) {
+      httpHeaders = creds?.simpleLoginCookieHeader;
+    }
+
+    // For ui_login, append ?token= since cached_network_image can't
+    // reliably inject Authorization headers across platforms. Use the
+    // un-tokened URL as cacheKey so token rotation doesn't bust cache.
+    var fetchUrl = baseApi;
+    if (authType == AuthType.uiLogin &&
+        creds?.uiAccessToken != null &&
+        creds!.uiAccessToken!.isNotEmpty) {
+      final sep = fetchUrl.contains('?') ? '&' : '?';
+      fetchUrl =
+          '$fetchUrl${sep}token=${Uri.encodeQueryComponent(creds.uiAccessToken!)}';
+    }
 
     final ImageRenderMethodForWeb renderMethod;
-    if (authType == AuthType.basic && basicToken != null) {
+    if (httpHeaders != null) {
       renderMethod = ImageRenderMethodForWeb.HttpGet;
     } else {
       renderMethod = ImageRenderMethodForWeb.HtmlImage;
@@ -119,7 +135,8 @@ class ServerImage extends HookConsumerWidget {
 
     return CachedNetworkImage(
       key: key.value,
-      imageUrl: baseApi,
+      imageUrl: fetchUrl,
+      cacheKey: baseApi,
       height: size?.height,
       cacheManager: DefaultCacheManager(),
       httpHeaders: httpHeaders,

--- a/lib/src/widgets/server_image.dart
+++ b/lib/src/widgets/server_image.dart
@@ -49,7 +49,7 @@ class ServerImage extends HookConsumerWidget {
     final key = useState(UniqueKey());
     // Providers
     final authType = ref.watch(authTypeKeyProvider);
-    final basicToken = ref.watch(credentialsProvider);
+    final basicToken = ref.watch(credentialsProvider).valueOrNull;
 
     final baseApi = "${Endpoints.baseApi(
       baseUrl: ref.watch(serverUrlProvider),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import connectivity_plus
 import file_picker
+import flutter_secure_storage_macos
 import network_info_plus
 import package_info_plus
 import path_provider_foundation
@@ -17,6 +18,7 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -473,6 +473,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_staggered_grid_view:
     dependency: transitive
     description:
@@ -783,10 +831,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: tachidesk_sorayomi
 description: A manga reader client for Suwayomi Server.
 
 publish_to: "none"
-version: 0.6.4+1
+version: 0.6.4+2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_markdown: ^0.7.1
+  flutter_secure_storage: ^9.2.2
   fluttertoast: ^8.1.1
   font_awesome_flutter: ^10.2.1
   freezed_annotation: ^2.2.0

--- a/test/src/features/auth/data/auth_credentials_store_test.dart
+++ b/test/src/features/auth/data/auth_credentials_store_test.dart
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/auth_credentials_store.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/secure_credentials_provider.dart';
+
+class _InMemorySecureStorage implements FlutterSecureStorage {
+  _InMemorySecureStorage([Map<String, String>? seed])
+      : _store = {...?seed};
+  final Map<String, String> _store;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _store.remove(key);
+    } else {
+      _store[key] = value;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async =>
+      _store[key];
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _store.remove(key);
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} not stubbed');
+}
+
+ProviderContainer _container(_InMemorySecureStorage storage) =>
+    ProviderContainer(overrides: [
+      secureStorageProvider.overrideWithValue(storage),
+    ]);
+
+void main() {
+  group('AuthCredentialsStore — build() (load from secure storage)', () {
+    test('build loads existing values from secure storage into state',
+        () async {
+      final storage = _InMemorySecureStorage({
+        'auth.ui.accessToken': 'A',
+        'auth.ui.refreshToken': 'R',
+        'auth.simple.cookie': 'JSESSIONID=abc',
+        'auth.password': 'hunter2',
+      });
+      final c = _container(storage);
+      addTearDown(c.dispose);
+
+      final state = await c.read(authCredentialsStoreProvider.future);
+      expect(state.uiAccessToken, 'A');
+      expect(state.uiRefreshToken, 'R');
+      expect(state.simpleLoginCookie, 'JSESSIONID=abc');
+      expect(state.password, 'hunter2');
+    });
+
+    test('build returns empty state when nothing is stored', () async {
+      final storage = _InMemorySecureStorage();
+      final c = _container(storage);
+      addTearDown(c.dispose);
+
+      final state = await c.read(authCredentialsStoreProvider.future);
+      expect(state.uiAccessToken, isNull);
+      expect(state.simpleLoginCookie, isNull);
+    });
+  });
+
+  group('AuthCredentialsStore — UI Login', () {
+    test('saveUiLoginTokens persists AND updates state', () async {
+      final storage = _InMemorySecureStorage();
+      final c = _container(storage);
+      addTearDown(c.dispose);
+
+      // Force build so the notifier exists.
+      await c.read(authCredentialsStoreProvider.future);
+
+      final store = c.read(authCredentialsStoreProvider.notifier);
+      await store.saveUiLoginTokens(
+        accessToken: 'ACCESS123',
+        refreshToken: 'REFRESH456',
+      );
+
+      // Backing store written.
+      expect(await storage.read(key: 'auth.ui.accessToken'), 'ACCESS123');
+      expect(await storage.read(key: 'auth.ui.refreshToken'), 'REFRESH456');
+      // Riverpod state updated synchronously (no reload needed).
+      final state = c.read(authCredentialsStoreProvider).requireValue;
+      expect(state.uiAccessToken, 'ACCESS123');
+      expect(state.uiRefreshToken, 'REFRESH456');
+      // Convenience header projection.
+      expect(state.uiAuthorizationHeader, {'Authorization': 'Bearer ACCESS123'});
+    });
+
+    test('clearUiLoginTokens removes both tokens from store AND state',
+        () async {
+      final storage = _InMemorySecureStorage({
+        'auth.ui.accessToken': 'A',
+        'auth.ui.refreshToken': 'R',
+      });
+      final c = _container(storage);
+      addTearDown(c.dispose);
+      await c.read(authCredentialsStoreProvider.future);
+
+      final store = c.read(authCredentialsStoreProvider.notifier);
+      await store.clearUiLoginTokens();
+
+      expect(await storage.read(key: 'auth.ui.accessToken'), isNull);
+      expect(await storage.read(key: 'auth.ui.refreshToken'), isNull);
+      final state = c.read(authCredentialsStoreProvider).requireValue;
+      expect(state.uiAccessToken, isNull);
+      expect(state.uiAuthorizationHeader, isNull);
+    });
+
+    test('updateUiLoginAccessToken updates only the access token', () async {
+      final storage = _InMemorySecureStorage({
+        'auth.ui.accessToken': 'OLD',
+        'auth.ui.refreshToken': 'REFRESH',
+      });
+      final c = _container(storage);
+      addTearDown(c.dispose);
+      await c.read(authCredentialsStoreProvider.future);
+
+      final store = c.read(authCredentialsStoreProvider.notifier);
+      await store.updateUiLoginAccessToken('NEW');
+
+      final state = c.read(authCredentialsStoreProvider).requireValue;
+      expect(state.uiAccessToken, 'NEW');
+      expect(state.uiRefreshToken, 'REFRESH',
+          reason: 'refresh token must not be touched on access rotation');
+    });
+  });
+
+  group('AuthCredentialsStore — Simple Login', () {
+    test('saveSimpleLoginCookie persists AND updates state', () async {
+      final storage = _InMemorySecureStorage();
+      final c = _container(storage);
+      addTearDown(c.dispose);
+      await c.read(authCredentialsStoreProvider.future);
+
+      final store = c.read(authCredentialsStoreProvider.notifier);
+      await store.saveSimpleLoginCookie('JSESSIONID=abc123');
+
+      final state = c.read(authCredentialsStoreProvider).requireValue;
+      expect(state.simpleLoginCookie, 'JSESSIONID=abc123');
+      expect(state.simpleLoginCookieHeader, {'Cookie': 'JSESSIONID=abc123'});
+    });
+
+    test('clearSimpleLoginCookie removes the cookie from store + state',
+        () async {
+      final storage =
+          _InMemorySecureStorage({'auth.simple.cookie': 'JSESSIONID=x'});
+      final c = _container(storage);
+      addTearDown(c.dispose);
+      await c.read(authCredentialsStoreProvider.future);
+
+      final store = c.read(authCredentialsStoreProvider.notifier);
+      await store.clearSimpleLoginCookie();
+
+      final state = c.read(authCredentialsStoreProvider).requireValue;
+      expect(state.simpleLoginCookie, isNull);
+      expect(state.simpleLoginCookieHeader, isNull);
+    });
+  });
+
+  group('AuthCredentialsStore — password', () {
+    test('savePassword persists AND updates state', () async {
+      final storage = _InMemorySecureStorage();
+      final c = _container(storage);
+      addTearDown(c.dispose);
+      await c.read(authCredentialsStoreProvider.future);
+
+      final store = c.read(authCredentialsStoreProvider.notifier);
+      await store.savePassword('hunter2');
+
+      expect(await storage.read(key: 'auth.password'), 'hunter2');
+      expect(c.read(authCredentialsStoreProvider).requireValue.password,
+          'hunter2');
+    });
+  });
+
+  group('AuthCredentialsStore — basic credentials (migrated)', () {
+    test('clearBasicCredentials removes the secure-storage entry', () async {
+      final storage = _InMemorySecureStorage({
+        'auth.basic.credentials': 'Basic YWFyb246aHVudGVyMg==',
+      });
+      final c = _container(storage);
+      addTearDown(c.dispose);
+      await c.read(authCredentialsStoreProvider.future);
+
+      final store = c.read(authCredentialsStoreProvider.notifier);
+      await store.clearBasicCredentials();
+
+      expect(await storage.read(key: 'auth.basic.credentials'), isNull);
+    });
+  });
+}

--- a/test/src/features/auth/data/basic_auth_migration_test.dart
+++ b/test/src/features/auth/data/basic_auth_migration_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/basic_auth_migration.dart';
+
+class _InMemorySecureStorage implements FlutterSecureStorage {
+  final Map<String, String> _store = {};
+  @override
+  Future<void> write({required String key, required String? value,
+      IOSOptions? iOptions, AndroidOptions? aOptions, LinuxOptions? lOptions,
+      WebOptions? webOptions, MacOsOptions? mOptions,
+      WindowsOptions? wOptions}) async {
+    if (value == null) _store.remove(key); else _store[key] = value;
+  }
+  @override
+  Future<String?> read({required String key, IOSOptions? iOptions,
+      AndroidOptions? aOptions, LinuxOptions? lOptions, WebOptions? webOptions,
+      MacOsOptions? mOptions, WindowsOptions? wOptions}) async => _store[key];
+  @override
+  Future<void> delete({required String key, IOSOptions? iOptions,
+      AndroidOptions? aOptions, LinuxOptions? lOptions, WebOptions? webOptions,
+      MacOsOptions? mOptions, WindowsOptions? wOptions}) async => _store.remove(key);
+  @override
+  noSuchMethod(Invocation i) => throw UnimplementedError();
+}
+
+void main() {
+  group('migrateBasicAuthCredentials', () {
+    test('moves legacy SharedPreferences credential to secure storage',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'basicCredentials': 'Basic YWFyb246aHVudGVyMg==',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final secure = _InMemorySecureStorage();
+
+      await migrateBasicAuthCredentials(prefs: prefs, secure: secure);
+
+      expect(prefs.getString('basicCredentials'), isNull);
+      expect(await secure.read(key: 'auth.basic.credentials'),
+          'Basic YWFyb246aHVudGVyMg==');
+    });
+
+    test('is a no-op when no legacy credential exists', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final secure = _InMemorySecureStorage();
+
+      await migrateBasicAuthCredentials(prefs: prefs, secure: secure);
+
+      expect(await secure.read(key: 'auth.basic.credentials'), isNull);
+    });
+
+    test('is a no-op when secure storage already has the value (idempotent)',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'basicCredentials': 'Basic NEW_VALUE',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final secure = _InMemorySecureStorage();
+      await secure.write(
+          key: 'auth.basic.credentials', value: 'Basic OLD_VALUE');
+
+      await migrateBasicAuthCredentials(prefs: prefs, secure: secure);
+
+      // Existing secure-store value wins; legacy plaintext is still cleared.
+      expect(await secure.read(key: 'auth.basic.credentials'),
+          'Basic OLD_VALUE');
+      expect(prefs.getString('basicCredentials'), isNull);
+    });
+  });
+}

--- a/test/src/features/auth/data/classify_auth_error_test.dart
+++ b/test/src/features/auth/data/classify_auth_error_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io' show HandshakeException;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/auth_coordinator.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/simple_login_client.dart';
+
+void main() {
+  group('classifyAuthError', () {
+    test('HandshakeException → tls', () {
+      final result = classifyAuthError(
+        const HandshakeException('Wrong version number'),
+      );
+      expect(result.kind, TestConnectionFailureKind.tls);
+    });
+
+    test('arbitrary error mentioning "handshake" → tls', () {
+      final result = classifyAuthError(
+        Exception('OperationException: handshake failed during fetch'),
+      );
+      expect(result.kind, TestConnectionFailureKind.tls);
+    });
+
+    test('error mentioning "certificate" → tls', () {
+      final result = classifyAuthError(
+        Exception('Bad certificate from server'),
+      );
+      expect(result.kind, TestConnectionFailureKind.tls);
+    });
+
+    test('SocketException-shaped error → network (not tls)', () {
+      final result = classifyAuthError(
+        Exception('SocketException: Failed host lookup: foo.bar'),
+      );
+      expect(result.kind, TestConnectionFailureKind.network);
+    });
+
+    test('timeout → network', () {
+      final result = classifyAuthError(
+        Exception('TimeoutException: Future not completed'),
+      );
+      expect(result.kind, TestConnectionFailureKind.network);
+    });
+
+    test('unauthorized → invalidCredentials', () {
+      final result = classifyAuthError(
+        Exception('401 Unauthorized'),
+      );
+      expect(result.kind, TestConnectionFailureKind.invalidCredentials);
+    });
+
+    test('SimpleLoginAuthFailure → invalidCredentials', () {
+      final result = classifyAuthError(SimpleLoginAuthFailure());
+      expect(result.kind, TestConnectionFailureKind.invalidCredentials);
+    });
+
+    test('SimpleLoginShapeFailure → unexpectedShape (with detail)', () {
+      final result = classifyAuthError(SimpleLoginShapeFailure('odd body'));
+      expect(result.kind, TestConnectionFailureKind.unexpectedShape);
+      expect(result.detail, 'odd body');
+    });
+
+    test('unknown error → unexpectedShape (with detail)', () {
+      final result = classifyAuthError(Exception('mystery boom'));
+      expect(result.kind, TestConnectionFailureKind.unexpectedShape);
+      expect(result.detail, contains('mystery boom'));
+    });
+
+    test('TLS check beats network keyword collision', () {
+      // HandshakeException's toString contains "connection" via context.
+      // We want tls classification to win, not network.
+      final result = classifyAuthError(
+        Exception('TLS handshake error while opening connection'),
+      );
+      expect(result.kind, TestConnectionFailureKind.tls);
+    });
+  });
+}

--- a/test/src/features/auth/data/simple_login_client_test.dart
+++ b/test/src/features/auth/data/simple_login_client_test.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/simple_login_client.dart';
+
+void main() {
+  group('SimpleLoginClient', () {
+    test('login returns cookie value on 303', () async {
+      final mock = MockClient((request) async {
+        expect(request.url.toString(), 'https://server.test/login.html');
+        expect(request.headers['Content-Type'],
+            'application/x-www-form-urlencoded; charset=utf-8');
+        expect(request.bodyFields, {'user': 'aaron', 'pass': 'hunter2'});
+        return http.Response(
+          '',
+          303,
+          headers: {
+            'location': '/',
+            'set-cookie':
+                'JSESSIONID=abc.123; Path=/; HttpOnly',
+          },
+        );
+      });
+
+      final client = SimpleLoginClient(httpClient: mock);
+      final cookie = await client.login(
+        serverBaseUrl: 'https://server.test',
+        username: 'aaron',
+        password: 'hunter2',
+      );
+      expect(cookie, 'JSESSIONID=abc.123');
+    });
+
+    test('login throws SimpleLoginAuthFailure on 200 (re-rendered form)',
+        () async {
+      final mock = MockClient((request) async => http.Response(
+            '<html>Invalid username or password</html>',
+            200,
+          ));
+      final client = SimpleLoginClient(httpClient: mock);
+
+      expect(
+        () => client.login(
+          serverBaseUrl: 'https://server.test',
+          username: 'aaron',
+          password: 'wrong',
+        ),
+        throwsA(isA<SimpleLoginAuthFailure>()),
+      );
+    });
+
+    test('login throws SimpleLoginShapeFailure on unexpected status',
+        () async {
+      final mock = MockClient((request) async => http.Response('', 500));
+      final client = SimpleLoginClient(httpClient: mock);
+
+      expect(
+        () => client.login(
+          serverBaseUrl: 'https://server.test',
+          username: 'aaron',
+          password: 'hunter2',
+        ),
+        throwsA(isA<SimpleLoginShapeFailure>()),
+      );
+    });
+
+    test('login throws SimpleLoginShapeFailure when 303 has no Set-Cookie',
+        () async {
+      final mock = MockClient((request) async => http.Response(
+            '',
+            303,
+            headers: {'location': '/'},
+          ));
+      final client = SimpleLoginClient(httpClient: mock);
+
+      expect(
+        () => client.login(
+          serverBaseUrl: 'https://server.test',
+          username: 'aaron',
+          password: 'hunter2',
+        ),
+        throwsA(isA<SimpleLoginShapeFailure>()),
+      );
+    });
+  });
+}

--- a/test/src/features/auth/data/suwayomi_auth_link_test.dart
+++ b/test/src/features/auth/data/suwayomi_auth_link_test.dart
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gql/language.dart';
+import 'package:graphql/client.dart';
+import 'package:tachidesk_sorayomi/src/constants/enum.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/auth_coordinator.dart';
+import 'package:tachidesk_sorayomi/src/features/auth/data/suwayomi_auth_link.dart';
+
+/// Records each downstream request and lets the test script the responses
+/// it returns. The next-in-link, after the SuwayomiAuthLink.
+class _RecorderLink extends Link {
+  _RecorderLink(this.responses);
+  final List<Response Function(Request)> responses;
+  int callCount = 0;
+  final List<Request> received = [];
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) async* {
+    received.add(request);
+    final fn = responses[callCount.clamp(0, responses.length - 1)];
+    callCount++;
+    yield fn(request);
+  }
+}
+
+/// Like `_RecorderLink` but emits multiple events for a single request —
+/// used to verify subscription-style streams aren't truncated by the
+/// auth link's first-event inspection.
+class _MultiEventLink extends Link {
+  _MultiEventLink(this.events);
+  final List<Response> events;
+  int callCount = 0;
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) async* {
+    callCount++;
+    for (final e in events) {
+      yield e;
+    }
+  }
+}
+
+Response _ok() => Response(data: {'ok': true}, response: {});
+
+Response _401() => Response(
+      data: null,
+      errors: [
+        const GraphQLError(message: 'Unauthorized', extensions: {
+          'http': {'status': 401},
+        }),
+      ],
+      response: {},
+    );
+
+Request _req() => Request(
+      operation: Operation(document: parseString('query Q { x }')),
+    );
+
+void main() {
+  group('SuwayomiAuthLink — UI Login', () {
+    test('injects Authorization: Bearer header from store', () async {
+      final recorder = _RecorderLink([(_) => _ok()]);
+      String? lastAuth;
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.uiLogin,
+        getHeaders: () async => {'Authorization': 'Bearer TOK'},
+        refreshAccessToken: () async => const RefreshAuthFailure(),
+        onNeedsReauth: () {},
+      );
+
+      await for (final _ in link.concat(recorder).request(_req())) {}
+
+      lastAuth = recorder.received.last.context
+          .entry<HttpLinkHeaders>()
+          ?.headers['Authorization'];
+      expect(lastAuth, 'Bearer TOK');
+    });
+
+    test('on 401, calls refresh and retries with new token (header asserts'
+        ' the retry uses FRESH, not STALE — R2-9)', () async {
+      int refreshCalls = 0;
+      final recorder = _RecorderLink([
+        (_) => _401(), // first call: 401
+        (_) => _ok(), // second call (after refresh): ok
+      ]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.uiLogin,
+        getHeaders: () async => {'Authorization': 'Bearer STALE'},
+        refreshAccessToken: () async {
+          refreshCalls++;
+          return const RefreshSuccess('FRESH');
+        },
+        onNeedsReauth: () {},
+      );
+
+      Response? lastResponse;
+      await for (final r in link.concat(recorder).request(_req())) {
+        lastResponse = r;
+      }
+
+      expect(refreshCalls, 1);
+      expect(recorder.callCount, 2);
+      expect(lastResponse?.data, {'ok': true});
+      // R2-9: the retried request MUST use the fresh token, not the stale
+      // one. A broken implementation that retried with STALE would pass
+      // the previous version of this test because the second scripted
+      // response is _ok() regardless of header.
+      expect(
+        recorder.received[0].context.entry<HttpLinkHeaders>()?.headers[
+            'Authorization'],
+        'Bearer STALE',
+        reason: 'first request uses the stale token before refresh',
+      );
+      expect(
+        recorder.received[1].context.entry<HttpLinkHeaders>()?.headers[
+            'Authorization'],
+        'Bearer FRESH',
+        reason: 'second request MUST use the freshly-refreshed token',
+      );
+    });
+
+    test('R2-4: retry also returns 401 → onNeedsReauth + surface 401',
+        () async {
+      bool reauthCalled = false;
+      final recorder = _RecorderLink([
+        (_) => _401(), // first call
+        (_) => _401(), // retry with FRESH token also 401
+      ]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.uiLogin,
+        getHeaders: () async => {'Authorization': 'Bearer STALE'},
+        refreshAccessToken: () async => const RefreshSuccess('FRESH'),
+        onNeedsReauth: () {
+          reauthCalled = true;
+        },
+      );
+
+      Response? lastResponse;
+      await for (final r in link.concat(recorder).request(_req())) {
+        lastResponse = r;
+      }
+
+      expect(reauthCalled, isTrue,
+          reason: 'second 401 after a fresh token must trigger reauth');
+      expect(recorder.callCount, 2);
+      expect(lastResponse?.errors?.first.message, 'Unauthorized');
+    });
+
+    test('transientFailure surfaces original 401 without setting reauth',
+        () async {
+      bool reauthCalled = false;
+      final recorder = _RecorderLink([(_) => _401()]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.uiLogin,
+        getHeaders: () async => {'Authorization': 'Bearer STALE'},
+        refreshAccessToken: () async =>
+            RefreshOutcome.transientFailure(Exception('network down')),
+        onNeedsReauth: () {
+          reauthCalled = true;
+        },
+      );
+
+      Response? lastResponse;
+      await for (final r in link.concat(recorder).request(_req())) {
+        lastResponse = r;
+      }
+
+      expect(reauthCalled, isFalse,
+          reason: 'transient (network) refresh failure must NOT mark '
+              'the session dead — the refresh token may still be good');
+      expect(lastResponse?.errors?.first.message, 'Unauthorized');
+    });
+
+    test('does NOT truncate multi-event streams (subscriptions): all '
+        'downstream events flow through', () async {
+      final downstream = _MultiEventLink([
+        Response(data: {'tick': 1}, response: {}),
+        Response(data: {'tick': 2}, response: {}),
+        Response(data: {'tick': 3}, response: {}),
+      ]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.uiLogin,
+        getHeaders: () async => {'Authorization': 'Bearer TOK'},
+        refreshAccessToken: () async => const RefreshAuthFailure(),
+        onNeedsReauth: () {},
+      );
+
+      final results = <Response>[];
+      await for (final r in link.concat(downstream).request(_req())) {
+        results.add(r);
+      }
+      expect(results.length, 3,
+          reason: 'subscription stream truncated — likely '
+              'await stream.first regression');
+      expect(results.map((r) => r.data?['tick']).toList(), [1, 2, 3]);
+    });
+
+    test('on 401 with auth-failure refresh, calls onNeedsReauth and '
+        'returns the 401', () async {
+      bool reauthCalled = false;
+      final recorder = _RecorderLink([(_) => _401()]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.uiLogin,
+        getHeaders: () async => {'Authorization': 'Bearer STALE'},
+        refreshAccessToken: () async => const RefreshAuthFailure(),
+        onNeedsReauth: () {
+          reauthCalled = true;
+        },
+      );
+
+      Response? lastResponse;
+      await for (final r in link.concat(recorder).request(_req())) {
+        lastResponse = r;
+      }
+
+      expect(reauthCalled, isTrue);
+      expect(lastResponse?.errors?.first.message, 'Unauthorized');
+    });
+
+    // Note: process-wide single-flight is now an AuthCoordinator concern,
+    // not the Link's (R2-3). See AuthCoordinator tests for the dedup
+    // assertion; the Link itself just calls `refreshAccessToken` once per
+    // 401 it sees, and trusts the coordinator to handle concurrency.
+    test('R2-3: Link delegates refresh; one 401 → exactly one refresh call',
+        () async {
+      int refreshCalls = 0;
+      final recorder = _RecorderLink([(_) => _401(), (_) => _ok()]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.uiLogin,
+        getHeaders: () async => {'Authorization': 'Bearer STALE'},
+        refreshAccessToken: () async {
+          refreshCalls++;
+          return const RefreshSuccess('FRESH');
+        },
+        onNeedsReauth: () {},
+      );
+
+      await for (final _ in link.concat(recorder).request(_req())) {}
+
+      expect(refreshCalls, 1,
+          reason: 'Link should invoke refreshAccessToken exactly once '
+              'per 401 — coordinator dedup is its own concern');
+    });
+  });
+
+  group('SuwayomiAuthLink — Simple Login', () {
+    test('injects Cookie header from store', () async {
+      final recorder = _RecorderLink([(_) => _ok()]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.simpleLogin,
+        getHeaders: () async => {'Cookie': 'JSESSIONID=abc'},
+        refreshAccessToken: () async => const RefreshAuthFailure(),
+        onNeedsReauth: () {},
+      );
+
+      await for (final _ in link.concat(recorder).request(_req())) {}
+
+      final cookie = recorder.received.last.context
+          .entry<HttpLinkHeaders>()
+          ?.headers['Cookie'];
+      expect(cookie, 'JSESSIONID=abc');
+    });
+
+    test('on 401, calls onNeedsReauth (no refresh path)', () async {
+      bool reauthCalled = false;
+      final recorder = _RecorderLink([(_) => _401()]);
+      final link = SuwayomiAuthLink(
+        authType: () => AuthType.simpleLogin,
+        getHeaders: () async => {'Cookie': 'JSESSIONID=stale'},
+        refreshAccessToken: () async => const RefreshAuthFailure(),
+        onNeedsReauth: () {
+          reauthCalled = true;
+        },
+      );
+
+      await for (final _ in link.concat(recorder).request(_req())) {}
+
+      expect(reauthCalled, isTrue);
+    });
+  });
+}

--- a/test/src/features/settings/presentation/server/is_local_address_test.dart
+++ b/test/src/features/settings/presentation/server/is_local_address_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tachidesk_sorayomi/src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart';
+
+void main() {
+  group('isLocalAddress', () {
+    test('localhost', () {
+      expect(isLocalAddress('http://localhost'), isTrue);
+      expect(isLocalAddress('http://localhost:4567'), isTrue);
+      expect(isLocalAddress('http://LOCALHOST:4567/api'), isTrue);
+    });
+
+    test('127.x.x.x loopback', () {
+      expect(isLocalAddress('http://127.0.0.1'), isTrue);
+      expect(isLocalAddress('http://127.0.0.1:8080/api/graphql'), isTrue);
+      expect(isLocalAddress('http://127.255.255.255'), isTrue);
+    });
+
+    test('192.168.x.x', () {
+      expect(isLocalAddress('http://192.168.2.4:4568'), isTrue);
+      expect(isLocalAddress('http://192.168.0.1'), isTrue);
+    });
+
+    test('10.x.x.x', () {
+      expect(isLocalAddress('http://10.0.0.1'), isTrue);
+      expect(isLocalAddress('http://10.255.255.255'), isTrue);
+    });
+
+    test('172.16-31.x.x', () {
+      expect(isLocalAddress('http://172.16.0.1'), isTrue);
+      expect(isLocalAddress('http://172.20.50.50'), isTrue);
+      expect(isLocalAddress('http://172.31.255.255'), isTrue);
+      // 172.15 and 172.32 are NOT in the private range
+      expect(isLocalAddress('http://172.15.0.1'), isFalse);
+      expect(isLocalAddress('http://172.32.0.1'), isFalse);
+    });
+
+    test('public addresses are not local', () {
+      expect(isLocalAddress('http://suwayomi.typhon.one'), isFalse);
+      expect(isLocalAddress('https://example.com'), isFalse);
+      expect(isLocalAddress('http://8.8.8.8'), isFalse);
+      expect(isLocalAddress('http://1.1.1.1'), isFalse);
+    });
+
+    test('malformed inputs', () {
+      expect(isLocalAddress(''), isFalse);
+      expect(isLocalAddress('not a url'), isFalse);
+      expect(isLocalAddress('http://'), isFalse);
+      expect(isLocalAddress('http://999.999.999.999'), isFalse);
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,15 @@
 #include "generated_plugin_registrant.h"
 
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
+  flutter_secure_storage_windows
   permission_handler_windows
   url_launcher_windows
 )


### PR DESCRIPTION
Adds support for Suwayomi's native authentication so users on `simple_login` or `ui_login` server modes can log in. The app currently only supports basic auth, so anyone whose server uses simple/ui login can't authenticate.

Includes:
- `simple_login` and `ui_login`: the credential flow wired into the GraphQL client and image requests, with access-token refresh.
- Credentials stored in `flutter_secure_storage`; existing basic-auth credentials are migrated over from SharedPreferences.
- A custom GraphQL `Link` that attaches the access token and does a single-flight refresh when it expires, with a re-auth banner if refresh fails.
- Settings UI to choose the auth mode and enter credentials, with connection testing and clearer error messages for TLS / reverse-proxy setups.

The GraphQL schema is refreshed to v2.2.2100 to pick up the `login`/`refreshToken` mutations.

Tested on device against a live instance behind a reverse proxy. Unit tests cover the credential store, the auth-link refresh, the simple-login client, and error classification.

Closes #370
