### PR TITLE
Fix chapter action bar overlapping the Android navigation bar

### DIFF
--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -43,8 +43,18 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
 
     final selectedList = selectedChapters.value.values;
 
+    // This bar is a Scaffold bottomSheet inside the shell navigation, which
+    // zeroes the bottom MediaQuery insets — BOTH padding and viewPadding — for
+    // its descendants (confirmed on-device: MediaQuery reports 0 while the
+    // system navigation bar is really 48dp). Read the inset straight from the
+    // FlutterView, which no MediaQuery ancestor can consume, so the bar clears
+    // the Android navigation buttons.
+    final view = View.of(context);
+    final bottomInset = view.viewPadding.bottom / view.devicePixelRatio;
     return Padding(
-      padding: KEdgeInsets.a8.size,
+      padding: KEdgeInsets.a8.size.add(
+        EdgeInsets.only(bottom: bottomInset),
+      ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [


### PR DESCRIPTION
On Android with the 3-button navigation bar (edge-to-edge), the multi-select chapter action bar overlapped the system navigation buttons.

The bar is a `Scaffold` `bottomSheet` inside the shell navigation, which zeroes the bottom MediaQuery insets — both `padding` and `viewPadding` — for its descendants, so `SafeArea` and MediaQuery-based padding read `0` and add nothing. Reading the inset directly from the `FlutterView` (`View.of(context).viewPadding`) gives the real navigation-bar height, which no MediaQuery ancestor can consume, so the bar sits above the navigation buttons.

Affects the manga details and updates screens (both mount this bar).
