### PR TITLE
Fix download list tile bottom overflow

### DIFF
--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -57,7 +57,6 @@ class DownloadsScreen extends ConsumerWidget {
             return RefreshIndicator(
               onRefresh: () => ref.refresh(downloadStatusProvider.future),
               child: ListView.builder(
-                itemExtent: 104,
                 itemBuilder: (context, index) {
                   if (index == downloadsCount) return const Gap(104);
                   final chapterId = downloadsChapterIds[index];


### PR DESCRIPTION
The downloads list pins each row to `itemExtent: 104`, but a download tile (cover thumbnail, title/chapter/status `ListTile`, progress bar, and the up/down reorder buttons) needs roughly 124px — so every row renders a "BOTTOM OVERFLOWED BY 20 PIXELS" error.

Dropping the fixed `itemExtent` lets each tile size to its content, which fixes the overflow and also avoids re-overflowing at larger text scales. The trailing spacer (`Gap(104)` for FAB clearance) is unaffected.
